### PR TITLE
Add product listing index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Monitta Store Products</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 2rem;
+        background-color: #f7f7f7;
+      }
+
+      h1 {
+        text-align: center;
+        color: #333;
+      }
+
+      #products {
+        list-style: disc;
+        padding-left: 1.75rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      #products li {
+        background: #fff;
+        border-radius: 0.5rem;
+        padding: 0.75rem 1rem;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      #products img {
+        width: 64px;
+        height: 64px;
+        object-fit: cover;
+        border-radius: 0.5rem;
+        flex-shrink: 0;
+      }
+
+      #status {
+        margin: 1.5rem 0;
+        text-align: center;
+        color: #555;
+      }
+
+      .product-link {
+        font-weight: 600;
+        color: #1a73e8;
+        text-decoration: none;
+      }
+
+      .product-link:hover,
+      .product-link:focus {
+        text-decoration: underline;
+      }
+
+      .product-description {
+        color: #555;
+        margin: 0.15rem 0 0;
+      }
+
+      .product-text {
+        display: flex;
+        flex-direction: column;
+        gap: 0.1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Monitta Store Products</h1>
+    <div id="status">Loading products…</div>
+    <ul id="products" hidden></ul>
+
+    <template id="product-template">
+      <li>
+        <img alt="Product thumbnail" loading="lazy" />
+        <div class="product-text">
+          <a class="product-link" target="_blank" rel="noopener"></a>
+          <p class="product-description"></p>
+        </div>
+      </li>
+    </template>
+
+    <script>
+      const endpoint = "https://localhost:7193/MonittaStore";
+      const statusEl = document.getElementById("status");
+      const listEl = document.getElementById("products");
+      const template = document.getElementById("product-template");
+
+      function resolveField(product, candidates, fallback = "") {
+        for (const key of candidates) {
+          if (key in product && product[key]) {
+            return product[key];
+          }
+        }
+        return fallback;
+      }
+
+      async function loadProducts() {
+        try {
+          const response = await fetch(endpoint);
+          if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+          }
+
+          const data = await response.json();
+          const products = Array.isArray(data)
+            ? data
+            : Array.isArray(data?.products)
+            ? data.products
+            : Array.isArray(data?.items)
+            ? data.items
+            : [];
+
+          if (products.length === 0) {
+            statusEl.textContent = "No products found.";
+            return;
+          }
+
+          const fragment = document.createDocumentFragment();
+
+          for (const product of products) {
+            const clone = template.content.cloneNode(true);
+            const link = clone.querySelector(".product-link");
+            const description = clone.querySelector(".product-description");
+            const image = clone.querySelector("img");
+
+            const title =
+              resolveField(product, ["name", "title", "productName"], "View product");
+            const url = resolveField(product, ["url", "link", "productUrl", "href"]);
+            const imageUrl = resolveField(product, [
+              "imageUrl",
+              "image",
+              "thumbnailUrl",
+              "thumbnail",
+              "picture",
+            ]);
+            const summary = resolveField(product, ["description", "summary", "details"]);
+
+            link.textContent = title;
+            link.href = url || "#";
+            link.target = url ? "_blank" : "_self";
+
+            if (summary) {
+              description.textContent = summary;
+            } else if (url) {
+              description.textContent = url;
+            } else {
+              description.textContent = JSON.stringify(product, null, 2);
+            }
+
+            if (imageUrl) {
+              image.src = imageUrl;
+              image.alt = `${title} thumbnail`;
+            } else {
+              image.remove();
+            }
+
+            fragment.appendChild(clone);
+          }
+
+          listEl.appendChild(fragment);
+          listEl.hidden = false;
+          statusEl.textContent = "";
+        } catch (error) {
+          console.error(error);
+          statusEl.textContent =
+            "Failed to load products. Please ensure the API is running and accessible.";
+        }
+      }
+
+      loadProducts();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone index.html that fetches products from the Monitta Store endpoint
- render products as linked bullet points with optional thumbnails and descriptions
- include friendly loading and error states for API responses

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cbb8cf9fc0832599af2ea62d8bfa59