### PR TITLE
Redirect to edit page after product creation

### DIFF
--- a/product_add.html
+++ b/product_add.html
@@ -176,7 +176,6 @@
 
         <div class="actions">
           <button type="button" data-action="create">Utwórz</button>
-          <button type="button" data-action="save" hidden>Zapisz</button>
         </div>
       </form>
     </main>
@@ -186,7 +185,6 @@
         const styleNameInput = document.getElementById("style-name");
         const descriptionInput = document.getElementById("description");
         const createButton = document.querySelector('[data-action="create"]');
-        const saveButton = document.querySelector('[data-action="save"]');
         const statusElement = document.createElement("p");
 
         statusElement.setAttribute("role", "status");
@@ -195,7 +193,6 @@
         form.appendChild(statusElement);
 
         const state = {
-          createdProduct: null,
           isCreating: false,
         };
 
@@ -208,20 +205,6 @@
 
           statusElement.textContent = message;
           statusElement.style.color = colors[type] ?? colors.info;
-        };
-
-        const toggleButtons = (isCreated) => {
-          createButton.hidden = isCreated;
-          saveButton.hidden = !isCreated;
-        };
-
-        const persistProduct = (product) => {
-          try {
-            window.createdProduct = product;
-            localStorage.setItem("createdProduct", JSON.stringify(product));
-          } catch (error) {
-            console.warn("Nie udało się zapisać produktu w LocalStorage", error);
-          }
         };
 
         const createProduct = async () => {
@@ -248,22 +231,38 @@
             const response = await fetch(
               "https://vintagecrawlerappservice-hqb0f5bmfrdwf0g7.polandcentral-01.azurewebsites.net/products",
               {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify(payload),
-            });
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify(payload),
+              }
+            );
 
             if (!response.ok) {
               throw new Error(`Żądanie nie powiodło się (status: ${response.status})`);
             }
 
             const productDetails = await response.json();
-            state.createdProduct = productDetails;
-            persistProduct(productDetails);
-            toggleButtons(true);
-            showMessage("Produkt został pomyślnie utworzony.", "success");
+            const productId =
+              productDetails?.id ??
+              productDetails?.productId ??
+              productDetails?.productID ??
+              productDetails?.Id;
+
+            if (!productId) {
+              showMessage(
+                "Produkt został utworzony, ale nie udało się uzyskać identyfikatora produktu.",
+                "error"
+              );
+              return;
+            }
+
+            showMessage("Produkt został pomyślnie utworzony. Przekierowywanie...", "success");
+
+            const redirectUrl = new URL("product_edit.html", window.location.href);
+            redirectUrl.searchParams.set("productID", productId);
+            window.location.href = redirectUrl.toString();
           } catch (error) {
             console.error("Błąd podczas tworzenia produktu:", error);
             showMessage(
@@ -276,34 +275,7 @@
           }
         };
 
-        const handleSave = () => {
-          if (!state.createdProduct) {
-            showMessage("Brak produktu do zapisania.", "error");
-            return;
-          }
-
-          showMessage("Produkt gotowy do zapisania.", "success");
-        };
-
         createButton.addEventListener("click", createProduct);
-        saveButton.addEventListener("click", handleSave);
-
-        const previouslyCreatedProduct = localStorage.getItem("createdProduct");
-        if (previouslyCreatedProduct) {
-          try {
-            const parsedProduct = JSON.parse(previouslyCreatedProduct);
-            if (parsedProduct?.name) {
-              state.createdProduct = parsedProduct;
-              styleNameInput.value = parsedProduct.name ?? "";
-              descriptionInput.value = parsedProduct.description ?? "";
-              toggleButtons(true);
-              showMessage("Załadowano zapisany produkt.", "info");
-            }
-          } catch (error) {
-            console.warn("Nie udało się odczytać produktu z LocalStorage", error);
-            localStorage.removeItem("createdProduct");
-          }
-        }
       })();
     </script>
   </body>

--- a/product_edit.html
+++ b/product_edit.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="pl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Edytuj produkt</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(145deg, #f7f7f7, #e9ecf1);
+        padding: 2rem 1rem;
+      }
+
+      main {
+        width: min(520px, 100%);
+        margin-inline: auto;
+        background: #ffffff;
+        border-radius: 18px;
+        padding: 2.5rem 2rem;
+        box-shadow: 0 18px 45px rgba(15, 23, 42, 0.1);
+        display: flex;
+        flex-direction: column;
+        gap: 1.75rem;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(1.75rem, 2vw + 1rem, 2.4rem);
+        text-align: center;
+        color: #212936;
+      }
+
+      p {
+        margin: 0;
+        font-size: 1.05rem;
+        color: #1f2937;
+        line-height: 1.6;
+      }
+
+      .highlight {
+        font-weight: 600;
+        color: #6366f1;
+      }
+
+      .actions {
+        display: flex;
+        justify-content: center;
+      }
+
+      a.button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        border-radius: 999px;
+        padding: 0.85rem 2.5rem;
+        font-weight: 600;
+        font-size: 1rem;
+        background: linear-gradient(120deg, #6366f1, #8b5cf6);
+        color: #ffffff;
+        text-decoration: none;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.2s ease;
+      }
+
+      a.button:hover,
+      a.button:focus {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 24px rgba(99, 102, 241, 0.25);
+        outline: none;
+      }
+
+      a.button:active {
+        transform: translateY(1px);
+        box-shadow: 0 6px 14px rgba(99, 102, 241, 0.25);
+      }
+
+      @media (max-width: 480px) {
+        main {
+          padding: 2rem 1.5rem;
+        }
+
+        a.button {
+          width: 100%;
+        }
+      }
+
+      .status-error {
+        color: #b91c1c;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Edytuj produkt</h1>
+      <p id="product-status">Trwa ładowanie danych produktu…</p>
+      <div class="actions">
+        <a class="button" href="product_add.html">Dodaj nowy produkt</a>
+      </div>
+    </main>
+    <script>
+      (function () {
+        const statusElement = document.getElementById("product-status");
+        const searchParams = new URLSearchParams(window.location.search);
+        const productId = searchParams.get("productID");
+
+        if (!productId) {
+          statusElement.textContent =
+            "Nie znaleziono identyfikatora produktu w adresie URL.";
+          statusElement.classList.add("status-error");
+          return;
+        }
+
+        const trimmedId = productId.trim();
+
+        if (!trimmedId) {
+          statusElement.textContent =
+            "Przekazany identyfikator produktu jest pusty.";
+          statusElement.classList.add("status-error");
+          return;
+        }
+
+        statusElement.innerHTML =
+          'Produkt o identyfikatorze <span class="highlight"></span> jest gotowy do edycji.';
+
+        const idElement = statusElement.querySelector(".highlight");
+        idElement.textContent = trimmedId;
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- rename the product creation page to `product_add.html`, remove the unused save button, and redirect to the edit view after a successful API response
- add a `product_edit.html` page that surfaces the product identifier from the URL and links back to product creation

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc0792242c83258c0e22d16b0348dd