### PR TITLE
Remove file upload option from product add page

### DIFF
--- a/product_add.html
+++ b/product_add.html
@@ -60,8 +60,7 @@
       }
 
       input[type="text"],
-      textarea,
-      input[type="file"] {
+      textarea {
         width: 100%;
         border-radius: 12px;
         border: 1px solid #d1d5db;
@@ -73,8 +72,7 @@
       }
 
       input[type="text"]:focus,
-      textarea:focus,
-      input[type="file"]:focus {
+      textarea:focus {
         outline: none;
         border-color: #6366f1;
         box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.1);
@@ -160,18 +158,6 @@
             rows="5"
             required
           ></textarea>
-        </div>
-
-        <div class="field">
-          <label for="product-images">Zdjęcia produktu</label>
-          <input
-            type="file"
-            id="product-images"
-            name="product-images"
-            accept="image/*"
-            multiple
-          />
-          <p class="hint">Możesz dodać jedno lub więcej zdjęć produktu.</p>
         </div>
 
         <div class="actions">


### PR DESCRIPTION
## Summary
- remove the product image upload field from `product_add.html` to prevent adding files
- update the form styling to drop unused selectors for file inputs

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc0a7baabc8325927fd649efbe9a80