### PR TITLE
Support productID query parameter on edit page

### DIFF
--- a/product_edit.html
+++ b/product_edit.html
@@ -291,7 +291,7 @@
           "https://vintagecrawlerappservice-hqb0f5bmfrdwf0g7.polandcentral-01.azurewebsites.net/products";
 
         const params = new URLSearchParams(window.location.search);
-        const productId = params.get("id");
+        const productId = params.get("productID") ?? params.get("id");
 
         const setStatus = (message, type = "info") => {
           statusElement.textContent = message;
@@ -447,7 +447,10 @@
 
         const loadProduct = async () => {
           if (!productId) {
-            setStatus("Brak identyfikatora produktu w adresie URL.", "error");
+            setStatus(
+              "Brak identyfikatora produktu w adresie URL. Użyj parametru ?productID=…",
+              "error"
+            );
             return;
           }
 


### PR DESCRIPTION
## Summary
- allow the product edit page to read a product identifier provided as the `productID` query parameter
- clarify the status message shown when the product identifier is missing from the URL

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc0adaab308325b97c6bce9f58faa2