### PR TITLE
Add product details page with carousel and Monitta matches

### DIFF
--- a/product2.html
+++ b/product2.html
@@ -1,0 +1,1156 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Product details</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      :root {
+        color-scheme: light;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont,
+          sans-serif;
+        background: linear-gradient(160deg, #f7f8fc 0%, #eef2ff 40%, #f5f5f5 100%);
+        color: #0f172a;
+      }
+
+      a {
+        color: #2563eb;
+        text-decoration: none;
+      }
+
+      a:hover,
+      a:focus-visible {
+        text-decoration: underline;
+      }
+
+      .page {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: clamp(1.5rem, 4vw, 3rem) clamp(1rem, 4vw, 2.5rem) 4rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+
+      .back-link {
+        align-self: flex-start;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.4rem 0.75rem;
+        border-radius: 999px;
+        background: rgba(37, 99, 235, 0.08);
+        color: #1d4ed8;
+        font-weight: 600;
+        transition: background 0.2s ease, transform 0.2s ease;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 0.9em;
+      }
+
+      .back-link:hover,
+      .back-link:focus-visible {
+        background: rgba(37, 99, 235, 0.16);
+        transform: translateY(-1px);
+      }
+
+      .product-header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
+
+      .product-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4vw, 2.8rem);
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
+
+      .product-id {
+        margin: 0;
+        color: #64748b;
+        font-size: 0.95rem;
+      }
+
+      .status {
+        margin: 0;
+        padding: 0.85rem 1.1rem;
+        border-radius: 0.75rem;
+        background: rgba(14, 165, 233, 0.12);
+        border: 1px solid rgba(14, 165, 233, 0.2);
+        color: #0f172a;
+        font-weight: 500;
+        backdrop-filter: blur(8px);
+      }
+
+      .product-description {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.7;
+        color: #1f2937;
+      }
+
+      .product-description--muted {
+        color: #64748b;
+        font-style: italic;
+      }
+
+      .muted {
+        color: #6b7280;
+        margin: 0;
+      }
+
+      .content {
+        display: grid;
+        grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        align-items: start;
+      }
+
+      @media (max-width: 960px) {
+        .content {
+          grid-template-columns: 1fr;
+        }
+
+        .monitta {
+          order: 2;
+        }
+      }
+
+      .media {
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+      }
+
+      .carousel {
+        position: relative;
+        overflow: hidden;
+        border-radius: clamp(1rem, 3vw, 1.5rem);
+        background: radial-gradient(circle at top left, #1f2937, #0f172a);
+        box-shadow: 0 28px 55px rgba(15, 23, 42, 0.28);
+        min-height: clamp(280px, 45vw, 520px);
+        isolation: isolate;
+      }
+
+      .carousel-track {
+        display: flex;
+        width: 100%;
+        height: 100%;
+        transition: transform 0.45s ease-in-out;
+      }
+
+      .carousel-slide {
+        flex: 0 0 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: clamp(1rem, 3vw, 2.25rem);
+      }
+
+      .carousel-slide img {
+        width: 100%;
+        height: 100%;
+        max-height: clamp(260px, 50vw, 540px);
+        object-fit: contain;
+        border-radius: clamp(0.75rem, 2vw, 1.25rem);
+        background: #111827;
+        box-shadow: 0 18px 45px rgba(15, 23, 42, 0.35);
+      }
+
+      .carousel-button {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 42px;
+        height: 42px;
+        border-radius: 999px;
+        border: none;
+        background: rgba(255, 255, 255, 0.82);
+        color: #0f172a;
+        font-size: 1.35rem;
+        font-weight: 600;
+        display: grid;
+        place-items: center;
+        cursor: pointer;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.25);
+        transition: transform 0.2s ease, background 0.2s ease, opacity 0.2s ease;
+      }
+
+      .carousel-button:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+        box-shadow: none;
+      }
+
+      .carousel-button:hover:not(:disabled),
+      .carousel-button:focus-visible:not(:disabled) {
+        transform: translateY(-50%) scale(1.05);
+        background: #f8fafc;
+      }
+
+      .carousel-button--prev {
+        left: clamp(0.75rem, 2vw, 1.5rem);
+      }
+
+      .carousel-button--next {
+        right: clamp(0.75rem, 2vw, 1.5rem);
+      }
+
+      .carousel-indicators {
+        position: absolute;
+        bottom: clamp(0.75rem, 2vw, 1.5rem);
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        gap: 0.6rem;
+        padding: 0.35rem 0.75rem;
+        border-radius: 999px;
+        background: rgba(15, 23, 42, 0.35);
+        backdrop-filter: blur(18px);
+      }
+
+      .carousel-indicator {
+        width: 11px;
+        height: 11px;
+        border-radius: 999px;
+        border: none;
+        background: rgba(255, 255, 255, 0.55);
+        cursor: pointer;
+        transition: width 0.2s ease, background 0.2s ease, transform 0.2s ease;
+      }
+
+      .carousel-indicator.is-active {
+        width: 28px;
+        background: #ffffff;
+      }
+
+      .carousel-indicator:focus-visible {
+        outline: 2px solid rgba(59, 130, 246, 0.9);
+        outline-offset: 2px;
+      }
+
+      .monitta {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .monitta-title {
+        margin: 0;
+        font-size: clamp(1.5rem, 3vw, 2rem);
+        font-weight: 700;
+        color: #111827;
+      }
+
+      .monitta-list {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .monitta-card {
+        background: rgba(255, 255, 255, 0.9);
+        border-radius: 1rem;
+        padding: clamp(0.9rem, 2vw, 1.1rem);
+        display: flex;
+        gap: clamp(0.85rem, 2vw, 1.25rem);
+        align-items: stretch;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        box-shadow: 0 18px 38px rgba(15, 23, 42, 0.16);
+        backdrop-filter: blur(12px);
+      }
+
+      .monitta-card__image-link {
+        width: clamp(128px, 20vw, 160px);
+        border-radius: 0.85rem;
+        overflow: hidden;
+        display: block;
+        background: linear-gradient(135deg, #e2e8f0, #f8fafc);
+        position: relative;
+        flex-shrink: 0;
+        aspect-ratio: 3 / 4;
+      }
+
+      .monitta-card__image-link img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+        transition: transform 0.3s ease;
+      }
+
+      .monitta-card__image-link:hover img,
+      .monitta-card__image-link:focus-visible img {
+        transform: scale(1.03);
+      }
+
+      .monitta-card__placeholder {
+        width: 100%;
+        height: 100%;
+        display: grid;
+        place-items: center;
+        color: #475569;
+        font-size: 0.85rem;
+        font-weight: 600;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+      }
+
+      .monitta-card__body {
+        display: flex;
+        flex-direction: column;
+        gap: 0.45rem;
+        padding-right: 0.25rem;
+      }
+
+      .monitta-card__title {
+        font-size: 1.05rem;
+        font-weight: 650;
+        color: #0f172a;
+      }
+
+      .monitta-card__subtitle {
+        margin: 0;
+        color: #64748b;
+        font-size: 0.9rem;
+      }
+
+      .monitta-card__price {
+        margin: 0.25rem 0 0;
+        font-size: 1.05rem;
+        font-weight: 700;
+        color: #047857;
+      }
+
+      .monitta-card__meta {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.15rem 0.75rem;
+        margin: 0.35rem 0 0;
+        font-size: 0.85rem;
+        color: #475569;
+      }
+
+      .monitta-card__meta dt {
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
+      .monitta-card__meta dd {
+        margin: 0;
+        font-weight: 600;
+        color: #111827;
+      }
+
+      @media (max-width: 720px) {
+        .monitta-card {
+          flex-direction: column;
+        }
+
+        .monitta-card__image-link {
+          width: 100%;
+          aspect-ratio: 4 / 3;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .carousel-track,
+        .carousel-button,
+        .carousel-indicator,
+        .monitta-card__image-link img {
+          transition: none !important;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <a class="back-link" href="products.html">Back to products</a>
+      <header class="product-header">
+        <h1 id="product-title">Loading product…</h1>
+        <p id="product-id" class="product-id"></p>
+      </header>
+      <p id="status" class="status" hidden></p>
+      <p id="product-description" class="product-description" hidden></p>
+      <section class="content" hidden>
+        <section class="media">
+          <div
+            id="product-carousel"
+            class="carousel"
+            aria-label="Product images"
+            aria-roledescription="carousel"
+            hidden
+          >
+            <button
+              type="button"
+              class="carousel-button carousel-button--prev"
+              aria-label="Previous image"
+            >
+              ‹
+            </button>
+            <div class="carousel-track" aria-live="polite"></div>
+            <button
+              type="button"
+              class="carousel-button carousel-button--next"
+              aria-label="Next image"
+            >
+              ›
+            </button>
+            <div class="carousel-indicators"></div>
+          </div>
+          <p id="no-images" class="muted" hidden>No product images available.</p>
+        </section>
+        <aside class="monitta">
+          <h2 class="monitta-title">Vintage matches</h2>
+          <p id="monitta-status" class="muted">Loading related listings…</p>
+          <div id="monitta-list" class="monitta-list"></div>
+        </aside>
+      </section>
+    </main>
+
+    <script>
+      (function () {
+        const imageBaseUrl =
+          "https://buythelookvintagestorage.blob.core.windows.net/uploads/";
+        const imageToken =
+          "?sv=2024-11-04&ss=bfqt&srt=sco&sp=rl&se=2026-09-18T22:54:01Z&st=2025-09-18T14:39:01Z&spr=https&sig=roACoFS1yrHnyvMnUZWwy7w1VTfvQBL2jRCA9zGRdfA%3D";
+        const productsEndpointBase =
+          "https://vintagecrawlerappservice-hqb0f5bmfrdwf0g7.polandcentral-01.azurewebsites.net/products/";
+        const monittaEndpoint =
+          "https://vintagecrawlerappservice-hqb0f5bmfrdwf0g7.polandcentral-01.azurewebsites.net/MonittaStore";
+
+        const params = new URLSearchParams(window.location.search);
+        const productIdFromQuery =
+          params.get("productID") ||
+          params.get("productId") ||
+          params.get("id") ||
+          params.get("product");
+
+        const statusEl = document.getElementById("status");
+        const titleEl = document.getElementById("product-title");
+        const productIdEl = document.getElementById("product-id");
+        const descriptionEl = document.getElementById("product-description");
+        const contentEl = document.querySelector(".content");
+        const carouselEl = document.getElementById("product-carousel");
+        const carouselTrackEl = carouselEl.querySelector(".carousel-track");
+        const prevButton = carouselEl.querySelector(".carousel-button--prev");
+        const nextButton = carouselEl.querySelector(".carousel-button--next");
+        const indicatorsEl = carouselEl.querySelector(".carousel-indicators");
+        const noImagesEl = document.getElementById("no-images");
+        const monittaStatusEl = document.getElementById("monitta-status");
+        const monittaListEl = document.getElementById("monitta-list");
+
+        const carouselState = {
+          images: [],
+          currentIndex: 0,
+          title: "",
+        };
+
+        monittaStatusEl.textContent = "Loading related listings…";
+        monittaStatusEl.hidden = false;
+
+        if (!productIdFromQuery) {
+          statusEl.textContent =
+            "Please provide a productID query parameter in the page URL.";
+          statusEl.hidden = false;
+          contentEl.hidden = true;
+          descriptionEl.hidden = true;
+          return;
+        }
+
+        productIdEl.textContent = `Product ID: ${productIdFromQuery}`;
+        productIdEl.hidden = false;
+
+        statusEl.textContent = "Loading product…";
+        statusEl.hidden = false;
+        contentEl.hidden = true;
+        descriptionEl.hidden = true;
+
+        prevButton.addEventListener("click", () => moveCarousel(-1));
+        nextButton.addEventListener("click", () => moveCarousel(1));
+
+        init(productIdFromQuery);
+
+        async function init(productId) {
+          try {
+            const product = await fetchProduct(productId);
+            renderProduct(product, productId);
+            statusEl.hidden = true;
+            contentEl.hidden = false;
+
+            const { items: monittaItems, error } = await loadMonittaStoreItems();
+            renderMonitta(product?.VintageProducts, monittaItems, error);
+          } catch (error) {
+            console.error("Failed to load product details.", error);
+            statusEl.textContent =
+              "We could not load product information. Please try again later.";
+            statusEl.hidden = false;
+            contentEl.hidden = true;
+          }
+        }
+
+        async function fetchProduct(productId) {
+          const url = `${productsEndpointBase}${encodeURIComponent(productId)}`;
+          const response = await fetch(url, {
+            headers: { Accept: "application/json" },
+          });
+
+          if (!response.ok) {
+            throw new Error(`Product request failed with status ${response.status}`);
+          }
+
+          return await response.json();
+        }
+
+        async function loadMonittaStoreItems() {
+          try {
+            const response = await fetch(monittaEndpoint, {
+              headers: { Accept: "application/json" },
+            });
+
+            if (!response.ok) {
+              throw new Error(
+                `Monitta Store request failed with status ${response.status}`,
+              );
+            }
+
+            const payload = await response.json();
+            const items = extractMonittaStoreItems(payload);
+            return { items, error: null };
+          } catch (error) {
+            console.error("Failed to load Monitta Store items.", error);
+            return { items: [], error };
+          }
+        }
+
+        function extractMonittaStoreItems(payload, visited = new Set()) {
+          if (!payload || visited.has(payload)) {
+            return [];
+          }
+
+          if (Array.isArray(payload)) {
+            return payload.filter((item) => item != null);
+          }
+
+          if (typeof payload !== "object") {
+            return [];
+          }
+
+          visited.add(payload);
+
+          const candidateKeys = ["items", "products", "data", "results", "value"];
+          for (const key of candidateKeys) {
+            if (Array.isArray(payload[key])) {
+              return payload[key].filter((item) => item != null);
+            }
+          }
+
+          for (const key of candidateKeys) {
+            const nested = payload[key];
+            if (nested && typeof nested === "object") {
+              const extracted = extractMonittaStoreItems(nested, visited);
+              if (extracted.length) {
+                return extracted;
+              }
+            }
+          }
+
+          for (const value of Object.values(payload)) {
+            if (value && typeof value === "object") {
+              const extracted = extractMonittaStoreItems(value, visited);
+              if (extracted.length) {
+                return extracted;
+              }
+            }
+          }
+
+          return [];
+        }
+
+        function renderProduct(product, fallbackProductId) {
+          const title =
+            product?.Name ||
+            product?.name ||
+            product?.Title ||
+            product?.title ||
+            "Product details";
+          titleEl.textContent = title;
+          document.title = `${title} • Product details`;
+
+          const idValue =
+            product?.id ||
+            product?.productId ||
+            product?.productID ||
+            product?.Id ||
+            fallbackProductId ||
+            "";
+          if (idValue) {
+            productIdEl.textContent = `Product ID: ${idValue}`;
+            productIdEl.hidden = false;
+          } else {
+            productIdEl.hidden = true;
+          }
+
+          const description =
+            product?.Description ||
+            product?.description ||
+            product?.Summary ||
+            product?.summary ||
+            "";
+
+          if (description) {
+            descriptionEl.textContent = description;
+            descriptionEl.classList.remove("product-description--muted");
+            descriptionEl.hidden = false;
+          } else {
+            descriptionEl.textContent = "This product does not include a description.";
+            descriptionEl.classList.add("product-description--muted");
+            descriptionEl.hidden = false;
+          }
+
+          const images = gatherProductImages(product?.Images);
+          carouselState.title = title;
+          renderCarousel(images);
+        }
+
+        function gatherProductImages(images) {
+          const result = [];
+          const seen = new Set();
+
+          function visit(value) {
+            if (!value) {
+              return;
+            }
+
+            if (Array.isArray(value)) {
+              for (const item of value) {
+                visit(item);
+              }
+              return;
+            }
+
+            const raw = resolveImageValue(value);
+            if (!raw) {
+              return;
+            }
+
+            const url = buildProductImageUrl(raw);
+            if (url && !seen.has(url)) {
+              seen.add(url);
+              result.push(url);
+            }
+          }
+
+          visit(images);
+
+          return result;
+        }
+
+        function resolveImageValue(value) {
+          if (!value) {
+            return "";
+          }
+
+          if (typeof value === "string") {
+            return value.trim();
+          }
+
+          if (typeof value === "number") {
+            return String(value);
+          }
+
+          if (value && typeof value === "object") {
+            const candidateKeys = [
+              "url",
+              "href",
+              "src",
+              "image",
+              "imageUrl",
+              "image_url",
+              "file",
+              "fileName",
+              "filename",
+              "name",
+              "value",
+            ];
+
+            for (const key of candidateKeys) {
+              if (key in value && value[key]) {
+                return resolveImageValue(value[key]);
+              }
+            }
+          }
+
+          return "";
+        }
+
+        function buildProductImageUrl(raw) {
+          if (!raw) {
+            return "";
+          }
+
+          if (/^https?:/i.test(raw)) {
+            return raw;
+          }
+
+          const sanitized = String(raw).replace(/^[/\\]+/, "");
+          if (!sanitized) {
+            return "";
+          }
+
+          const parts = sanitized
+            .split(/[/\\]+/)
+            .filter((part) => part)
+            .map((part) => encodeURIComponent(part));
+
+          if (!parts.length) {
+            return "";
+          }
+
+          return `${imageBaseUrl}${parts.join("/")}${imageToken}`;
+        }
+
+        function renderCarousel(images) {
+          carouselState.images = images;
+          carouselState.currentIndex = 0;
+
+          carouselTrackEl.innerHTML = "";
+          indicatorsEl.innerHTML = "";
+
+          if (!images.length) {
+            carouselEl.hidden = true;
+            noImagesEl.hidden = false;
+            prevButton.disabled = true;
+            nextButton.disabled = true;
+            return;
+          }
+
+          noImagesEl.hidden = true;
+          carouselEl.hidden = false;
+
+          images.forEach((url, index) => {
+            const slide = document.createElement("figure");
+            slide.className = "carousel-slide";
+            slide.setAttribute("role", "group");
+            slide.setAttribute("aria-roledescription", "slide");
+            slide.setAttribute(
+              "aria-label",
+              `Image ${index + 1} of ${images.length}`,
+            );
+
+            const img = document.createElement("img");
+            img.src = url;
+            img.alt = `${carouselState.title} – image ${index + 1} of ${images.length}`;
+            img.loading = index === 0 ? "eager" : "lazy";
+
+            slide.appendChild(img);
+            carouselTrackEl.appendChild(slide);
+
+            const indicator = document.createElement("button");
+            indicator.type = "button";
+            indicator.className = "carousel-indicator";
+            indicator.setAttribute("aria-label", `Show image ${index + 1}`);
+            indicator.addEventListener("click", () => {
+              carouselState.currentIndex = index;
+              updateCarousel();
+            });
+            indicatorsEl.appendChild(indicator);
+          });
+
+          updateCarousel();
+        }
+
+        function moveCarousel(direction) {
+          const { images } = carouselState;
+          if (!images.length) {
+            return;
+          }
+
+          const nextIndex = carouselState.currentIndex + direction;
+          carouselState.currentIndex = Math.max(
+            0,
+            Math.min(images.length - 1, nextIndex),
+          );
+          updateCarousel();
+        }
+
+        function updateCarousel() {
+          const { images, currentIndex } = carouselState;
+          const slideCount = images.length;
+
+          if (!slideCount) {
+            prevButton.disabled = true;
+            nextButton.disabled = true;
+            return;
+          }
+
+          carouselTrackEl.style.transform = `translateX(-${currentIndex * 100}%)`;
+          prevButton.disabled = currentIndex === 0;
+          nextButton.disabled = currentIndex === slideCount - 1;
+
+          const hideControls = slideCount <= 1;
+          prevButton.hidden = hideControls;
+          nextButton.hidden = hideControls;
+          indicatorsEl.hidden = hideControls;
+
+          const indicators = indicatorsEl.querySelectorAll(".carousel-indicator");
+          indicators.forEach((indicator, index) => {
+            const isActive = index === currentIndex;
+            indicator.classList.toggle("is-active", isActive);
+            indicator.setAttribute("aria-current", isActive ? "true" : "false");
+            indicator.disabled = isActive;
+          });
+        }
+
+        function renderMonitta(vintageProducts, monittaItems, error) {
+          monittaListEl.innerHTML = "";
+
+          const matches = [];
+          const monittaMap = new Map();
+          for (const item of monittaItems) {
+            if (!item) {
+              continue;
+            }
+            const idValue =
+              item.id ??
+              item.Id ??
+              item.itemId ??
+              item.itemID ??
+              item.ID ??
+              item.vintageProductId ??
+              item.vintage_product_id;
+            if (idValue == null) {
+              continue;
+            }
+            monittaMap.set(String(idValue), item);
+          }
+
+          if (Array.isArray(vintageProducts)) {
+            for (const vintage of vintageProducts) {
+              const vintageId = resolveVintageProductId(vintage);
+              if (!vintageId) {
+                continue;
+              }
+              const match = monittaMap.get(String(vintageId));
+              if (match) {
+                matches.push({ vintage, item: match });
+              }
+            }
+          }
+
+          if (matches.length === 0) {
+            if (error) {
+              monittaStatusEl.textContent =
+                "We could not load related Monitta Store listings right now.";
+            } else if (
+              !Array.isArray(vintageProducts) ||
+              vintageProducts.length === 0
+            ) {
+              monittaStatusEl.textContent =
+                "This product does not have any associated vintage listings yet.";
+            } else {
+              monittaStatusEl.textContent =
+                "No matching Monitta Store listings were found for this product.";
+            }
+
+            monittaStatusEl.hidden = false;
+            return;
+          }
+
+          monittaStatusEl.hidden = true;
+
+          const fragment = document.createDocumentFragment();
+
+          for (const { vintage, item } of matches) {
+            fragment.appendChild(createMonittaCard(vintage, item));
+          }
+
+          monittaListEl.appendChild(fragment);
+        }
+
+        function resolveVintageProductId(vintageProduct) {
+          if (!vintageProduct) {
+            return "";
+          }
+
+          if (
+            typeof vintageProduct === "string" ||
+            typeof vintageProduct === "number"
+          ) {
+            return String(vintageProduct);
+          }
+
+          const candidateKeys = [
+            "VintageProductId",
+            "vintageProductId",
+            "id",
+            "Id",
+            "productId",
+            "productID",
+          ];
+
+          for (const key of candidateKeys) {
+            if (key in vintageProduct && vintageProduct[key] != null) {
+              return String(vintageProduct[key]);
+            }
+          }
+
+          return "";
+        }
+
+        function createMonittaCard(vintageProduct, monittaItem) {
+          const card = document.createElement("article");
+          card.className = "monitta-card";
+
+          const url = resolveMonittaUrl(monittaItem, vintageProduct);
+          const imageLink = document.createElement("a");
+          imageLink.className = "monitta-card__image-link";
+          if (url) {
+            imageLink.href = url;
+            if (url !== "#") {
+              imageLink.target = "_blank";
+              imageLink.rel = "noopener";
+            }
+          } else {
+            imageLink.href = "#";
+          }
+
+          const photoUrl = getFirstPhotoUrl(monittaItem);
+          if (photoUrl) {
+            const img = document.createElement("img");
+            const title =
+              monittaItem?.title ||
+              monittaItem?.name ||
+              vintageProduct?.VintageProductName ||
+              "Vintage listing photo";
+            img.src = photoUrl;
+            img.alt = `${title} – photo`;
+            img.loading = "lazy";
+            imageLink.appendChild(img);
+          } else {
+            const placeholder = document.createElement("div");
+            placeholder.className = "monitta-card__placeholder";
+            placeholder.textContent = "No image";
+            imageLink.appendChild(placeholder);
+          }
+
+          card.appendChild(imageLink);
+
+          const body = document.createElement("div");
+          body.className = "monitta-card__body";
+
+          const titleLink = document.createElement("a");
+          titleLink.className = "monitta-card__title";
+          if (url) {
+            titleLink.href = url;
+            if (url !== "#") {
+              titleLink.target = "_blank";
+              titleLink.rel = "noopener";
+            }
+          } else {
+            titleLink.href = "#";
+          }
+          titleLink.textContent =
+            monittaItem?.title ||
+            monittaItem?.name ||
+            vintageProduct?.VintageProductName ||
+            "View listing";
+          body.appendChild(titleLink);
+
+          if (
+            vintageProduct?.VintageProductName &&
+            vintageProduct.VintageProductName !== titleLink.textContent
+          ) {
+            const subtitle = document.createElement("p");
+            subtitle.className = "monitta-card__subtitle";
+            subtitle.textContent = vintageProduct.VintageProductName;
+            body.appendChild(subtitle);
+          }
+
+          const priceText = formatPrice(monittaItem?.price, monittaItem?.currency);
+          if (priceText) {
+            const priceEl = document.createElement("p");
+            priceEl.className = "monitta-card__price";
+            priceEl.textContent = priceText;
+            body.appendChild(priceEl);
+          }
+
+          const metaEntries = [];
+          const size = monittaItem?.size || monittaItem?.Size;
+          if (size) {
+            metaEntries.push({ label: "Size", value: size });
+          }
+          const status = monittaItem?.status || monittaItem?.Status;
+          if (status) {
+            metaEntries.push({ label: "Condition", value: status });
+          }
+          const brand = monittaItem?.brand || monittaItem?.Brand;
+          if (brand) {
+            metaEntries.push({ label: "Brand", value: brand });
+          }
+          const favourites =
+            monittaItem?.favourite_count ?? monittaItem?.favoriteCount;
+          if (typeof favourites === "number") {
+            metaEntries.push({
+              label: "Favourites",
+              value: favourites.toLocaleString(),
+            });
+          }
+
+          if (metaEntries.length) {
+            const metaList = document.createElement("dl");
+            metaList.className = "monitta-card__meta";
+
+            for (const entry of metaEntries) {
+              const dt = document.createElement("dt");
+              dt.textContent = entry.label;
+              const dd = document.createElement("dd");
+              dd.textContent = entry.value;
+              metaList.appendChild(dt);
+              metaList.appendChild(dd);
+            }
+
+            body.appendChild(metaList);
+          }
+
+          card.appendChild(body);
+
+          return card;
+        }
+
+        function resolveMonittaUrl(monittaItem, vintageProduct) {
+          const urlCandidates = [
+            monittaItem?.url,
+            monittaItem?.link,
+            monittaItem?.href,
+            monittaItem?.productUrl,
+            monittaItem?.path
+              ? `https://www.vinted.pl${monittaItem.path}`
+              : null,
+            vintageProduct?.VintageProductUrl,
+            vintageProduct?.vintageProductUrl,
+          ];
+
+          for (const candidate of urlCandidates) {
+            if (!candidate) {
+              continue;
+            }
+
+            if (candidate === "#") {
+              return "#";
+            }
+
+            if (/^https?:/i.test(candidate)) {
+              return candidate;
+            }
+
+            if (candidate.startsWith("/")) {
+              return `https://www.vinted.pl${candidate}`;
+            }
+
+            return candidate;
+          }
+
+          return "#";
+        }
+
+        function getFirstPhotoUrl(monittaItem) {
+          if (!monittaItem) {
+            return "";
+          }
+
+          const photos = Array.isArray(monittaItem.photos)
+            ? monittaItem.photos
+            : Array.isArray(monittaItem.Photos)
+            ? monittaItem.Photos
+            : [];
+
+          for (const photo of photos) {
+            if (!photo) {
+              continue;
+            }
+
+            const url =
+              photo.full_size_url ||
+              photo.fullSizeUrl ||
+              photo.url ||
+              photo.href ||
+              photo.image ||
+              photo.src;
+            if (url) {
+              return url;
+            }
+          }
+
+          return "";
+        }
+
+        function formatPrice(price, fallbackCurrency) {
+          if (price == null) {
+            return "";
+          }
+
+          let amount = price;
+          let currency = fallbackCurrency || "";
+
+          if (typeof price === "object") {
+            amount =
+              price.amount ??
+              price.value ??
+              price.Price ??
+              price.price ??
+              price.listingPrice ??
+              null;
+            currency =
+              price.currency_code ??
+              price.currencyCode ??
+              price.currency ??
+              currency ??
+              "";
+          }
+
+          if (amount == null || amount === "") {
+            return "";
+          }
+
+          const numericAmount = Number(amount);
+          if (Number.isFinite(numericAmount)) {
+            if (currency) {
+              try {
+                return new Intl.NumberFormat(undefined, {
+                  style: "currency",
+                  currency,
+                }).format(numericAmount);
+              } catch (error) {
+                console.warn("Currency formatting failed", error);
+                return `${numericAmount.toFixed(2)} ${currency}`;
+              }
+            }
+
+            return numericAmount.toLocaleString(undefined, {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            });
+          }
+
+          const amountText = String(amount);
+          return currency ? `${amountText} ${currency}` : amountText;
+        }
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `product2.html` page to display individual product details
- fetch product content via the API, render a carousel for images from blob storage, and hydrate metadata
- load Monitta Store listings, match them to vintage IDs, and surface the related items next to the carousel

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc2c25efbc83258e06a2d86c16121b