### PR TITLE
Display vintage product list alongside product media

### DIFF
--- a/product.html
+++ b/product.html
@@ -85,8 +85,146 @@
       .product-card__layout {
         display: grid;
         gap: clamp(1.75rem, 4vw, 2.75rem);
-        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        grid-template-columns: minmax(240px, 0.85fr) minmax(260px, 1fr)
+          minmax(260px, 1.1fr);
         align-items: start;
+      }
+
+      .product-vintage {
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+        background: linear-gradient(135deg, rgba(96, 165, 250, 0.12), rgba(99, 102, 241, 0.08));
+        border-radius: 18px;
+        padding: clamp(1rem, 2.2vw, 1.25rem);
+        box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.12);
+        min-height: 100%;
+      }
+
+      .product-vintage__heading {
+        margin: 0;
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: #1e3a8a;
+      }
+
+      .product-vintage__empty {
+        margin: 0;
+        color: #4b5563;
+        font-size: 0.95rem;
+      }
+
+      .product-vintage__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        max-height: clamp(18rem, 45vh, 26rem);
+        overflow-y: auto;
+        padding-right: 0.25rem;
+        scrollbar-width: thin;
+      }
+
+      .product-vintage__list::-webkit-scrollbar {
+        width: 0.45rem;
+      }
+
+      .product-vintage__list::-webkit-scrollbar-track {
+        background: transparent;
+      }
+
+      .product-vintage__list::-webkit-scrollbar-thumb {
+        background: rgba(148, 163, 184, 0.5);
+        border-radius: 999px;
+      }
+
+      .product-vintage__item {
+        list-style: none;
+      }
+
+      .product-vintage__link {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        text-decoration: none;
+        color: inherit;
+        background: rgba(255, 255, 255, 0.7);
+        border-radius: 16px;
+        padding: 0.6rem 0.7rem;
+        transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      }
+
+      .product-vintage__link:hover,
+      .product-vintage__link:focus {
+        background: rgba(255, 255, 255, 0.95);
+        transform: translateY(-1px);
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+        outline: none;
+      }
+
+      .product-vintage__thumb {
+        flex: 0 0 auto;
+        width: 64px;
+        height: 64px;
+        border-radius: 14px;
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(135deg, rgba(14, 165, 233, 0.25), rgba(37, 99, 235, 0.25));
+        color: #1e3a8a;
+        font-weight: 600;
+        font-size: 1rem;
+        letter-spacing: 0.04em;
+      }
+
+      .product-vintage__thumb img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+
+      .product-vintage__thumb--placeholder {
+        background: linear-gradient(135deg, rgba(129, 140, 248, 0.18), rgba(14, 165, 233, 0.16));
+      }
+
+      .product-vintage__details {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+        min-width: 0;
+      }
+
+      .product-vintage__title {
+        font-weight: 600;
+        color: #0f172a;
+        font-size: 0.95rem;
+        line-height: 1.3;
+        word-break: break-word;
+      }
+
+      .product-vintage__identifier {
+        font-size: 0.8rem;
+        color: #64748b;
+        word-break: break-all;
+      }
+
+      .product-vintage__price {
+        font-size: 0.85rem;
+        color: #047857;
+        font-weight: 600;
+      }
+
+      @media (max-width: 1080px) {
+        .product-card__layout {
+          grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        }
+
+        .product-vintage__list {
+          max-height: clamp(18rem, 52vh, 28rem);
+        }
       }
 
       .product-media {
@@ -254,7 +392,8 @@
         }
 
         .product-carousel__indicator,
-        .product-carousel__nav {
+        .product-carousel__nav,
+        .product-vintage__link {
           transition: none;
         }
       }
@@ -412,6 +551,18 @@
           font-size: 1rem;
         }
 
+        .product-card__layout {
+          grid-template-columns: minmax(0, 1fr);
+        }
+
+        .product-vintage {
+          order: -1;
+        }
+
+        .product-vintage__list {
+          max-height: none;
+        }
+
         .product-media {
           min-height: 240px;
         }
@@ -440,6 +591,16 @@
 
       <article id="product-card" hidden>
         <div class="product-card__layout">
+          <section
+            class="product-vintage"
+            id="product-vintage-section"
+            hidden
+            aria-label="Related vintage products"
+          >
+            <h2 class="product-vintage__heading">Vintage products</h2>
+            <p class="product-vintage__empty" id="product-vintage-empty" hidden></p>
+            <ul class="product-vintage__list" id="product-vintage-list" hidden></ul>
+          </section>
           <div class="product-media" id="product-media">
             <div class="product-carousel" id="product-carousel" hidden>
               <button
@@ -507,6 +668,9 @@
       const monittaStoreEndpoint =
         "https://vintagecrawlerappservice-hqb0f5bmfrdwf0g7.polandcentral-01.azurewebsites.net/MonittaStore";
       const monittaStoreItems = [];
+      const monittaStoreItemsById = new Map();
+      let currentProductData = null;
+      let currentProductTitle = "";
       const imageBaseUrl =
         "https://buythelookvintagestorage.blob.core.windows.net/uploads/";
       const imageSasToken =
@@ -611,9 +775,15 @@
           );
 
           monittaStoreItems.splice(0, monittaStoreItems.length, ...items);
+          rebuildMonittaStoreIndex(monittaStoreItems);
         } catch (error) {
           console.error("Failed to load Monitta Store items.", error);
           monittaStoreItems.splice(0, monittaStoreItems.length);
+          monittaStoreItemsById.clear();
+        }
+
+        if (currentProductData) {
+          renderVintageProductsList(currentProductData);
         }
 
         return monittaStoreItems;
@@ -938,6 +1108,458 @@
         return urls;
       }
 
+      function normalizeIdentifier(value) {
+        if (value == null) {
+          return "";
+        }
+
+        if (typeof value === "string") {
+          return value.trim();
+        }
+
+        if (typeof value === "number" || typeof value === "bigint") {
+          return String(value);
+        }
+
+        if (typeof value === "boolean") {
+          return value ? "true" : "false";
+        }
+
+        if (value instanceof Date) {
+          return value.toISOString();
+        }
+
+        try {
+          return String(value).trim();
+        } catch (error) {
+          return "";
+        }
+      }
+
+      function gatherMonittaIdentifiers(item) {
+        const identifiers = new Set();
+
+        if (!item) {
+          return identifiers;
+        }
+
+        if (typeof item !== "object" || Array.isArray(item)) {
+          const normalized = normalizeIdentifier(item);
+          if (normalized) {
+            identifiers.add(normalized);
+          }
+          return identifiers;
+        }
+
+        const candidateKeys = [
+          "VintageProductId",
+          "vintageProductId",
+          "id",
+          "Id",
+          "ID",
+          "productId",
+          "productID",
+          "listingId",
+          "listingID",
+        ];
+
+        for (const key of candidateKeys) {
+          if (key in item) {
+            const normalized = normalizeIdentifier(item[key]);
+            if (normalized) {
+              identifiers.add(normalized);
+            }
+          }
+        }
+
+        return identifiers;
+      }
+
+      function rebuildMonittaStoreIndex(items) {
+        monittaStoreItemsById.clear();
+
+        const array = Array.isArray(items) ? items : [];
+        array.forEach((entry) => {
+          gatherMonittaIdentifiers(entry).forEach((identifier) => {
+            const key = identifier.toLowerCase();
+            if (!monittaStoreItemsById.has(key)) {
+              monittaStoreItemsById.set(key, entry);
+            }
+          });
+        });
+      }
+
+      function getMonittaPrimaryPhoto(entry) {
+        if (!entry || typeof entry !== "object") {
+          return "";
+        }
+
+        if ("photo" in entry && entry.photo != null && entry.photo !== "") {
+          const resolved = buildProductImageUrl(entry.photo);
+          if (resolved) {
+            return resolved;
+          }
+        }
+
+        const fallbackKeys = [
+          "photos",
+          "images",
+          "image",
+          "imageUrl",
+          "thumbnail",
+          "thumbnailUrl",
+          "picture",
+          "media",
+          "mediaUrls",
+          "photoUrls",
+          "thumbnails",
+          "mediaItems",
+        ];
+
+        for (const key of fallbackKeys) {
+          if (key in entry && entry[key] != null && entry[key] !== "") {
+            const resolved = buildProductImageUrl(entry[key]);
+            if (resolved) {
+              return resolved;
+            }
+          }
+        }
+
+        return "";
+      }
+
+      function getVintageProductIdentifier(source) {
+        if (source == null) {
+          return "";
+        }
+
+        if (typeof source === "object" && !Array.isArray(source)) {
+          const idCandidate = resolveField(
+            source,
+            [
+              "VintageProductId",
+              "vintageProductId",
+              "id",
+              "Id",
+              "ID",
+              "productId",
+              "productID",
+            ],
+            "",
+          );
+          const normalizedId = normalizeIdentifier(idCandidate);
+          if (normalizedId) {
+            return normalizedId;
+          }
+
+          const urlCandidate = resolveField(
+            source,
+            [
+              "VintageProductUrl",
+              "vintageProductUrl",
+              "url",
+              "link",
+              "productUrl",
+              "href",
+            ],
+            "",
+          );
+          const normalizedUrl = normalizeIdentifier(urlCandidate);
+          if (normalizedUrl) {
+            return normalizedUrl;
+          }
+
+          const nameCandidate = resolveField(
+            source,
+            [
+              "VintageProductName",
+              "vintageProductName",
+              "name",
+              "title",
+              "productName",
+              "label",
+            ],
+            "",
+          );
+          return normalizeIdentifier(nameCandidate);
+        }
+
+        return normalizeIdentifier(source);
+      }
+
+      function findMonittaEntryForVintageProduct(entry) {
+        if (!entry) {
+          return null;
+        }
+
+        const identifiers = new Set();
+        const directIdentifier = getVintageProductIdentifier(entry);
+        if (directIdentifier) {
+          identifiers.add(directIdentifier.toLowerCase());
+        }
+
+        if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+          gatherMonittaIdentifiers(entry).forEach((identifier) => {
+            identifiers.add(identifier.toLowerCase());
+          });
+        }
+
+        for (const key of identifiers) {
+          if (monittaStoreItemsById.has(key)) {
+            return monittaStoreItemsById.get(key);
+          }
+        }
+
+        return null;
+      }
+
+      function extractVintageProducts(product) {
+        if (!product || typeof product !== "object") {
+          return [];
+        }
+
+        const candidateKeys = [
+          "VintageProducts",
+          "vintageProducts",
+          "relatedProducts",
+        ];
+
+        const result = [];
+
+        for (const key of candidateKeys) {
+          const value = product[key];
+          if (Array.isArray(value)) {
+            value.forEach((item) => {
+              if (item != null) {
+                result.push(item);
+              }
+            });
+          }
+        }
+
+        return result;
+      }
+
+      function createVintageListItem(entry, index) {
+        const fallbackTitle = `Vintage product ${index + 1}`;
+        let title = fallbackTitle;
+        let identifier = "";
+        let url = "";
+        let priceText = "";
+
+        if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+          const resolvedTitle = resolveField(
+            entry,
+            [
+              "VintageProductName",
+              "vintageProductName",
+              "name",
+              "title",
+              "productName",
+              "label",
+            ],
+            fallbackTitle,
+          );
+          if (resolvedTitle != null && resolvedTitle !== "") {
+            const trimmedTitle = String(resolvedTitle).trim();
+            if (trimmedTitle) {
+              title = trimmedTitle;
+            }
+          }
+
+          const resolvedUrl = resolveField(
+            entry,
+            [
+              "VintageProductUrl",
+              "vintageProductUrl",
+              "url",
+              "link",
+              "productUrl",
+              "href",
+            ],
+            "",
+          );
+          if (resolvedUrl != null && resolvedUrl !== "") {
+            const trimmedUrl = String(resolvedUrl).trim();
+            if (trimmedUrl) {
+              url = trimmedUrl;
+            }
+          }
+
+          identifier = getVintageProductIdentifier(entry);
+
+          const priceValue = resolveField(
+            entry,
+            [
+              "priceFormatted",
+              "price",
+              "priceValue",
+              "amount",
+              "currentPrice",
+              "value",
+            ],
+            "",
+          );
+          const currencyValue = resolveField(
+            entry,
+            [
+              "currency",
+              "priceCurrency",
+              "currencyCode",
+              "currencySymbol",
+            ],
+            "",
+          );
+          const formattedPrice = formatPrice(priceValue, currencyValue);
+          if (formattedPrice) {
+            priceText = formattedPrice;
+          } else if (priceValue != null && priceValue !== "") {
+            const fallbackPrice = String(priceValue).trim();
+            if (fallbackPrice) {
+              priceText = fallbackPrice;
+            }
+          }
+        } else if (entry != null && entry !== "") {
+          const textValue = String(entry).trim();
+          if (textValue) {
+            title = textValue;
+            identifier = textValue;
+          }
+        }
+
+        const monittaEntry = findMonittaEntryForVintageProduct(entry);
+        let imageUrl = monittaEntry ? getMonittaPrimaryPhoto(monittaEntry) : "";
+
+        if (!imageUrl && entry && typeof entry === "object" && !Array.isArray(entry)) {
+          const fallbackImage = resolveField(
+            entry,
+            [
+              "photo",
+              "photos",
+              "image",
+              "imageUrl",
+              "thumbnail",
+              "thumbnailUrl",
+              "picture",
+            ],
+            "",
+          );
+          if (fallbackImage) {
+            imageUrl = buildProductImageUrl(fallbackImage);
+          }
+        }
+
+        const listItem = document.createElement("li");
+        listItem.className = "product-vintage__item";
+
+        const wrapper = document.createElement(url ? "a" : "div");
+        wrapper.className = "product-vintage__link";
+        if (url) {
+          wrapper.href = url;
+          wrapper.target = "_blank";
+          wrapper.rel = "noopener";
+        }
+
+        const thumb = document.createElement("div");
+        thumb.className = "product-vintage__thumb";
+
+        if (imageUrl) {
+          const image = document.createElement("img");
+          image.src = imageUrl;
+          image.alt = title ? `${title} – vintage product preview` : "Vintage product preview";
+          image.loading = "lazy";
+          image.decoding = "async";
+          thumb.appendChild(image);
+        } else {
+          thumb.classList.add("product-vintage__thumb--placeholder");
+          const fallbackCharacter = title ? title.charAt(0).toUpperCase() : "•";
+          thumb.textContent = fallbackCharacter || "•";
+        }
+
+        const details = document.createElement("div");
+        details.className = "product-vintage__details";
+
+        const nameElement = document.createElement("span");
+        nameElement.className = "product-vintage__title";
+        nameElement.textContent = title;
+        details.appendChild(nameElement);
+
+        const normalizedIdentifier = normalizeIdentifier(identifier);
+        if (normalizedIdentifier) {
+          const idElement = document.createElement("span");
+          idElement.className = "product-vintage__identifier";
+          idElement.textContent = `ID: ${normalizedIdentifier}`;
+          details.appendChild(idElement);
+        }
+
+        if (priceText) {
+          const priceElement = document.createElement("span");
+          priceElement.className = "product-vintage__price";
+          priceElement.textContent = priceText;
+          details.appendChild(priceElement);
+        }
+
+        wrapper.append(thumb, details);
+        listItem.appendChild(wrapper);
+
+        return {
+          element: listItem,
+          identifier: normalizedIdentifier,
+        };
+      }
+
+      function renderVintageProductsList(product) {
+        if (!vintageSection || !vintageListElement || !vintageEmptyElement) {
+          return;
+        }
+
+        if (!product || typeof product !== "object") {
+          vintageSection.hidden = true;
+          vintageListElement.innerHTML = "";
+          vintageListElement.hidden = true;
+          vintageEmptyElement.hidden = true;
+          return;
+        }
+
+        const entries = extractVintageProducts(product);
+        vintageListElement.innerHTML = "";
+        const seen = new Set();
+        let renderedCount = 0;
+
+        entries.forEach((entry, index) => {
+          const listItem = createVintageListItem(entry, index);
+          if (!listItem) {
+            return;
+          }
+
+          const key = listItem.identifier
+            ? listItem.identifier.toLowerCase()
+            : `__index-${index}`;
+          if (seen.has(key)) {
+            return;
+          }
+          seen.add(key);
+          vintageListElement.appendChild(listItem.element);
+          renderedCount += 1;
+        });
+
+        if (renderedCount > 0) {
+          vintageSection.hidden = false;
+          vintageListElement.hidden = false;
+          vintageEmptyElement.hidden = true;
+        } else {
+          const trimmedTitle =
+            typeof currentProductTitle === "string" ? currentProductTitle.trim() : "";
+          const listingName = trimmedTitle
+            ? `“${trimmedTitle}”`
+            : "this listing";
+          vintageEmptyElement.textContent = `No vintage products are linked to ${listingName}.`;
+          vintageSection.hidden = false;
+          vintageListElement.hidden = true;
+          vintageEmptyElement.hidden = false;
+        }
+      }
+
       const statusElement = document.getElementById("status");
       const productCard = document.getElementById("product-card");
       const productIdElement = document.getElementById("product-id");
@@ -950,6 +1572,9 @@
       const productAttributesElement = document.getElementById("product-attributes");
       const productRawSection = document.getElementById("product-raw-section");
       const productRawElement = document.getElementById("product-raw");
+      const vintageSection = document.getElementById("product-vintage-section");
+      const vintageListElement = document.getElementById("product-vintage-list");
+      const vintageEmptyElement = document.getElementById("product-vintage-empty");
       const imageFallback = document.getElementById("image-fallback");
       const productCarousel = document.getElementById("product-carousel");
       const carouselTrack = document.getElementById("product-carousel-track");
@@ -1400,6 +2025,9 @@
 
       async function loadProduct() {
         const productId = getProductIdFromQuery();
+        currentProductData = null;
+        currentProductTitle = "";
+        renderVintageProductsList(null);
 
         if (!productId) {
           statusElement.textContent =
@@ -1424,6 +2052,9 @@
           const product = extractProduct(payload);
 
           if (!product || typeof product !== "object") {
+            currentProductData = null;
+            currentProductTitle = "";
+            renderVintageProductsList(null);
             statusElement.textContent = "No product details were returned for this identifier.";
             productCard.hidden = true;
             return;
@@ -1434,6 +2065,10 @@
             `Product ${productId}`;
           productNameElement.textContent = title;
           document.title = `${title} – Monitta Store`;
+
+          currentProductTitle = title;
+          currentProductData = product;
+          renderVintageProductsList(product);
 
           const knownId = resolveField(product, [
             "id",
@@ -1552,6 +2187,9 @@
           productCard.hidden = false;
         } catch (error) {
           console.error(error);
+          currentProductData = null;
+          currentProductTitle = "";
+          renderVintageProductsList(null);
           statusElement.hidden = false;
           statusElement.textContent =
             "We could not load product information. Please verify the product ID and try again.";


### PR DESCRIPTION
## Summary
- add a vintage products sidebar before the product image carousel and update the layout to accommodate it
- render each vintage product with its Monitta Store thumbnail by matching VintageProductId to the Monitta dataset
- show helpful messaging and styling for the new list, including fallbacks when no related vintage products exist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc2cf039448325a0f7aed3bf728613