### PR TITLE
Simplify product page layout

### DIFF
--- a/product.html
+++ b/product.html
@@ -85,8 +85,7 @@
       .product-card__layout {
         display: grid;
         gap: clamp(1.75rem, 4vw, 2.75rem);
-        grid-template-columns: minmax(240px, 0.85fr) minmax(260px, 1fr)
-          minmax(260px, 1.1fr);
+        grid-template-columns: minmax(240px, 0.85fr) minmax(260px, 1fr);
         align-items: start;
       }
 
@@ -398,142 +397,6 @@
         }
       }
 
-      .product-info {
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-      }
-
-      .product-id {
-        margin: 0;
-        font-size: 0.95rem;
-        color: #64748b;
-      }
-
-      .product-name {
-        margin: 0;
-        font-size: clamp(1.85rem, 4.5vw, 2.6rem);
-        color: #111827;
-        line-height: 1.2;
-      }
-
-      .product-price {
-        margin: 0;
-        font-weight: 600;
-        color: #047857;
-        font-size: 1.15rem;
-      }
-
-      .product-price[hidden] {
-        display: none !important;
-      }
-
-      .product-description {
-        margin: 0;
-        color: #425466;
-        line-height: 1.65;
-        font-size: 1rem;
-      }
-
-      .product-description--muted {
-        color: #64748b;
-        font-style: italic;
-      }
-
-      .product-description--code {
-        font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular,
-          Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-        background: rgba(15, 23, 42, 0.06);
-        border-radius: 12px;
-        padding: 1rem 1.25rem;
-        white-space: pre-wrap;
-        word-break: break-word;
-      }
-
-      .product-actions {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.75rem;
-        margin-top: 0.5rem;
-      }
-
-      .product-actions[hidden] {
-        display: none !important;
-      }
-
-      .product-action {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: 0.5rem;
-        padding: 0.65rem 1.1rem;
-        border-radius: 999px;
-        text-decoration: none;
-        font-weight: 600;
-        color: #ffffff;
-        background: linear-gradient(120deg, #6366f1, #8b5cf6);
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
-      }
-
-      .product-action:hover,
-      .product-action:focus {
-        transform: translateY(-1px);
-        box-shadow: 0 14px 26px rgba(99, 102, 241, 0.25);
-        outline: none;
-      }
-
-      .product-section {
-        margin-top: 1.5rem;
-        padding-top: 1.5rem;
-        border-top: 1px solid rgba(148, 163, 184, 0.3);
-      }
-
-      .product-section h2 {
-        margin: 0 0 1rem;
-        font-size: 1.2rem;
-        color: #0f172a;
-      }
-
-      .product-attributes {
-        display: grid;
-        grid-template-columns: minmax(0, 180px) minmax(0, 1fr);
-        gap: 0.75rem 1.5rem;
-        margin: 0;
-      }
-
-      .product-attributes dt {
-        font-weight: 600;
-        color: #1e3a8a;
-        margin: 0;
-      }
-
-      .product-attributes dd {
-        margin: 0;
-        color: #334155;
-        line-height: 1.55;
-      }
-
-      .attribute-value--code {
-        font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular,
-          Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-        background: rgba(15, 23, 42, 0.04);
-        border-radius: 10px;
-        padding: 0.65rem 0.75rem;
-        white-space: pre-wrap;
-        word-break: break-word;
-      }
-
-      .product-raw {
-        margin: 0;
-        padding: 1.25rem 1.5rem;
-        background: #0f172a;
-        border-radius: 14px;
-        color: #e2e8f0;
-        font-size: 0.9rem;
-        line-height: 1.6;
-        overflow-x: auto;
-      }
-
       @media (max-width: 720px) {
         main {
           width: min(100%, calc(100% - 1.5rem));
@@ -567,9 +430,6 @@
           min-height: 240px;
         }
 
-        .product-attributes {
-          grid-template-columns: minmax(0, 140px) minmax(0, 1fr);
-        }
       }
     </style>
   </head>
@@ -636,28 +496,6 @@
             </div>
           </div>
 
-          <div class="product-info">
-            <p class="product-id" id="product-id" hidden></p>
-            <h2 class="product-name" id="product-name">Product</h2>
-            <p class="product-price" id="product-price" hidden></p>
-            <p class="product-description" id="product-description"></p>
-
-            <div class="product-actions" id="product-actions" hidden>
-              <a id="product-url" class="product-action" target="_blank" rel="noopener"
-                >Open original listing</a
-              >
-            </div>
-
-            <section class="product-section" id="product-attributes-section" hidden>
-              <h2>Key attributes</h2>
-              <dl class="product-attributes" id="product-attributes"></dl>
-            </section>
-
-            <section class="product-section" id="product-raw-section" hidden>
-              <h2>Raw API response</h2>
-              <pre class="product-raw" id="product-raw"></pre>
-            </section>
-          </div>
         </div>
       </article>
     </main>
@@ -1562,16 +1400,6 @@
 
       const statusElement = document.getElementById("status");
       const productCard = document.getElementById("product-card");
-      const productIdElement = document.getElementById("product-id");
-      const productNameElement = document.getElementById("product-name");
-      const productPriceElement = document.getElementById("product-price");
-      const productDescriptionElement = document.getElementById("product-description");
-      const productActionsElement = document.getElementById("product-actions");
-      const productUrlElement = document.getElementById("product-url");
-      const productAttributesSection = document.getElementById("product-attributes-section");
-      const productAttributesElement = document.getElementById("product-attributes");
-      const productRawSection = document.getElementById("product-raw-section");
-      const productRawElement = document.getElementById("product-raw");
       const vintageSection = document.getElementById("product-vintage-section");
       const vintageListElement = document.getElementById("product-vintage-list");
       const vintageEmptyElement = document.getElementById("product-vintage-empty");
@@ -1861,112 +1689,6 @@
         return "";
       }
 
-      function formatAttributeLabel(key) {
-        return key
-          .replace(/[_\-]+/g, " ")
-          .replace(/([a-z\d])([A-Z])/g, "$1 $2")
-          .replace(/\s+/g, " ")
-          .trim()
-          .replace(/\b\w/g, (match) => match.toUpperCase());
-      }
-
-      function formatAttributeValue(value) {
-        if (value == null) {
-          return null;
-        }
-
-        if (typeof value === "string") {
-          const trimmed = value.trim();
-          if (!trimmed) {
-            return null;
-          }
-          return { text: trimmed, isCode: false };
-        }
-
-        if (typeof value === "number" || typeof value === "bigint") {
-          return { text: String(value), isCode: false };
-        }
-
-        if (typeof value === "boolean") {
-          return { text: value ? "Yes" : "No", isCode: false };
-        }
-
-        if (Array.isArray(value)) {
-          if (!value.length) {
-            return null;
-          }
-
-          const formattedItems = [];
-          let hasCode = false;
-          for (const item of value) {
-            const formatted = formatAttributeValue(item);
-            if (formatted) {
-              formattedItems.push(formatted.text);
-              hasCode ||= formatted.isCode;
-            }
-          }
-
-          if (!formattedItems.length) {
-            return null;
-          }
-
-          return { text: formattedItems.join(", "), isCode: hasCode };
-        }
-
-        try {
-          return { text: JSON.stringify(value, null, 2), isCode: true };
-        } catch (error) {
-          return { text: String(value), isCode: true };
-        }
-      }
-
-      function formatDescription(product) {
-        const description = resolveField(product, [
-          "description",
-          "summary",
-          "details",
-          "text",
-          "subtitle",
-          "longDescription",
-        ]);
-
-        if (!description) {
-          return {
-            text: "No description is available for this product.",
-            isCode: false,
-            isFallback: true,
-          };
-        }
-
-        if (typeof description === "object") {
-          try {
-            return {
-              text: JSON.stringify(description, null, 2),
-              isCode: true,
-              isFallback: false,
-            };
-          } catch (error) {
-            return {
-              text: String(description),
-              isCode: true,
-              isFallback: false,
-            };
-          }
-        }
-
-        const text = String(description).trim();
-        if (!text) {
-          return {
-            text: "No description is available for this product.",
-            isCode: false,
-            isFallback: true,
-          };
-        }
-
-        const looksLikeJson = text.startsWith("{") || text.startsWith("[");
-        return { text, isCode: looksLikeJson, isFallback: false };
-      }
-
       function extractProduct(payload) {
         if (!payload) {
           return null;
@@ -1990,37 +1712,6 @@
         }
 
         return null;
-      }
-
-      function renderAttributes(product, excludeKeys) {
-        productAttributesElement.innerHTML = "";
-        const excluded = new Set(excludeKeys.map((key) => key.toLowerCase()));
-        let renderedCount = 0;
-
-        for (const [key, value] of Object.entries(product)) {
-          if (excluded.has(key.toLowerCase())) {
-            continue;
-          }
-
-          const formatted = formatAttributeValue(value);
-          if (!formatted) {
-            continue;
-          }
-
-          const dt = document.createElement("dt");
-          dt.textContent = formatAttributeLabel(key);
-
-          const dd = document.createElement("dd");
-          dd.textContent = formatted.text;
-          if (formatted.isCode || formatted.text.includes("\n")) {
-            dd.classList.add("attribute-value--code");
-          }
-
-          productAttributesElement.append(dt, dd);
-          renderedCount += 1;
-        }
-
-        productAttributesSection.hidden = renderedCount === 0;
       }
 
       async function loadProduct() {
@@ -2063,124 +1754,14 @@
           const title =
             resolveField(product, ["name", "title", "productName", "label"], `Product ${productId}`) ||
             `Product ${productId}`;
-          productNameElement.textContent = title;
           document.title = `${title} – Monitta Store`;
 
           currentProductTitle = title;
           currentProductData = product;
           renderVintageProductsList(product);
 
-          const knownId = resolveField(product, [
-            "id",
-            "productID",
-            "productId",
-            "listingId",
-            "sku",
-            "identifier",
-          ]);
-          if (knownId) {
-            productIdElement.textContent = `Product ID: ${knownId}`;
-            productIdElement.hidden = false;
-          } else {
-            productIdElement.textContent = `Product ID: ${productId}`;
-            productIdElement.hidden = false;
-          }
-
-          const priceValue = resolveField(product, [
-            "priceFormatted",
-            "price",
-            "priceValue",
-            "amount",
-            "currentPrice",
-            "salePrice",
-          ]);
-          const currency = resolveField(product, [
-            "currency",
-            "priceCurrency",
-            "currencyCode",
-            "currencySymbol",
-          ]);
-          const formattedPrice = formatPrice(priceValue, currency);
-          if (formattedPrice) {
-            productPriceElement.textContent = formattedPrice;
-            productPriceElement.hidden = false;
-          } else {
-            productPriceElement.hidden = true;
-          }
-
-          const { text: descriptionText, isCode: descriptionIsCode, isFallback } =
-            formatDescription(product);
-          productDescriptionElement.textContent = descriptionText;
-          productDescriptionElement.classList.toggle(
-            "product-description--code",
-            descriptionIsCode,
-          );
-          productDescriptionElement.classList.toggle(
-            "product-description--muted",
-            isFallback,
-          );
-
-          const productUrl = resolveField(product, ["url", "link", "productUrl", "href"]);
-          if (productUrl) {
-            productUrlElement.href = productUrl;
-            productUrlElement.hidden = false;
-            productActionsElement.hidden = false;
-          } else {
-            productUrlElement.removeAttribute("href");
-            productActionsElement.hidden = true;
-          }
-
           const imageUrls = getProductImageUrls(product);
           renderProductCarousel(imageUrls, title);
-
-          const excludedKeys = [
-            "name",
-            "title",
-            "productName",
-            "label",
-            "description",
-            "summary",
-            "details",
-            "text",
-            "subtitle",
-            "longDescription",
-            "url",
-            "link",
-            "productUrl",
-            "href",
-            "imageUrl",
-            "image",
-            "thumbnailUrl",
-            "thumbnail",
-            "picture",
-            "photo",
-            "priceFormatted",
-            "price",
-            "priceValue",
-            "amount",
-            "currentPrice",
-            "salePrice",
-            "currency",
-            "priceCurrency",
-            "currencyCode",
-            "currencySymbol",
-            "id",
-            "productID",
-            "productId",
-            "listingId",
-            "sku",
-            "identifier",
-          ];
-
-          renderAttributes(product, excludedKeys);
-
-          try {
-            productRawElement.textContent = JSON.stringify(product, null, 2);
-            productRawSection.hidden = false;
-          } catch (error) {
-            productRawElement.textContent = String(product);
-            productRawSection.hidden = false;
-          }
 
           statusElement.textContent = "";
           statusElement.hidden = true;


### PR DESCRIPTION
## Summary
- remove the right-hand product details column from `product.html`, leaving only the image carousel and vintage product list
- clean up related styles and client-side logic now that the detail elements are gone

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc333ec5588325a6720318443150e6