### PR TITLE
Add link from product edit page to list

### DIFF
--- a/product_edit.html
+++ b/product_edit.html
@@ -38,6 +38,32 @@
         gap: 2rem;
       }
 
+      .top-actions {
+        display: flex;
+        justify-content: flex-start;
+      }
+
+      .back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1.15rem;
+        border-radius: 999px;
+        background: rgba(99, 102, 241, 0.12);
+        color: #4338ca;
+        font-weight: 600;
+        text-decoration: none;
+        transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+      }
+
+      .back-link:hover,
+      .back-link:focus {
+        background: rgba(99, 102, 241, 0.2);
+        color: #312e81;
+        transform: translateY(-1px);
+        outline: none;
+      }
+
       header {
         text-align: center;
       }
@@ -547,6 +573,9 @@
   </head>
   <body>
     <main>
+      <div class="top-actions">
+        <a class="back-link" href="products.html">← Powrót do listy produktów</a>
+      </div>
       <header>
         <h1>Edycja produktu</h1>
         <p class="subtitle">


### PR DESCRIPTION
## Summary
- add a dedicated back link on the edit product screen to reach the product list
- style the navigation link to match the existing UI aesthetics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc3792ce4c83258bbc5aa87f481933