### PR TITLE
Add add-product action link on products page

### DIFF
--- a/products.html
+++ b/products.html
@@ -31,8 +31,41 @@
       }
 
       header {
+        position: relative;
         text-align: center;
         margin-bottom: clamp(2rem, 4vw, 3rem);
+        padding-top: clamp(0.75rem, 2.5vw, 1.25rem);
+      }
+
+      .header-action {
+        position: absolute;
+        top: 0;
+        right: 0;
+      }
+
+      .add-product-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.55rem 1.15rem;
+        border-radius: 999px;
+        background: linear-gradient(135deg, #2563eb, #7c3aed);
+        color: #ffffff;
+        font-weight: 600;
+        text-decoration: none;
+        box-shadow: 0 10px 20px rgba(79, 70, 229, 0.25);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .add-product-link:hover,
+      .add-product-link:focus {
+        transform: translateY(-1px);
+        box-shadow: 0 14px 28px rgba(79, 70, 229, 0.35);
+      }
+
+      .add-product-link:focus-visible {
+        outline: 3px solid rgba(37, 99, 235, 0.45);
+        outline-offset: 3px;
       }
 
       h1 {
@@ -172,6 +205,9 @@
   <body>
     <main>
       <header>
+        <div class="header-action">
+          <a class="add-product-link" href="product_add.html">Add Product</a>
+        </div>
         <h1>Monitta Store Products</h1>
         <p class="intro">
           Browse the latest products fetched directly from the Monitta Store product API.


### PR DESCRIPTION
## Summary
- add a prominently styled Add Product action link in the products page header
- ensure the link redirects users to the product_add.html form and keep header spacing comfortable for the new control

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68ccfc4379208325a8e059131fe92a50