### PR TITLE
Normalize product structure usage

### DIFF
--- a/product.html
+++ b/product.html
@@ -581,6 +581,72 @@
         }
       }
 
+      function toTrimmedString(value, fallback = "") {
+        if (typeof value === "string") {
+          const trimmed = value.trim();
+          return trimmed || fallback;
+        }
+
+        if (value == null) {
+          return fallback;
+        }
+
+        try {
+          const trimmed = String(value).trim();
+          return trimmed || fallback;
+        } catch (error) {
+          return fallback;
+        }
+      }
+
+      function normalizeVintageProduct(entry) {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          return null;
+        }
+
+        const normalized = { ...entry };
+        normalized.VintageProductId = toTrimmedString(entry.VintageProductId);
+        normalized.VintageProductName = toTrimmedString(entry.VintageProductName);
+        normalized.VintageProductUrl = toTrimmedString(entry.VintageProductUrl);
+        return normalized;
+      }
+
+      function normalizeProduct(rawProduct, fallbackId = "") {
+        if (!rawProduct || typeof rawProduct !== "object") {
+          return null;
+        }
+
+        const normalized = { ...rawProduct };
+        const normalizedId = toTrimmedString(
+          rawProduct.id ?? rawProduct.Id ?? rawProduct.ID,
+          fallbackId,
+        );
+        normalized.id = normalizedId;
+        normalized.Name = toTrimmedString(rawProduct.Name);
+        normalized.Description = toTrimmedString(rawProduct.Description);
+
+        const images = Array.isArray(rawProduct.Images) ? rawProduct.Images : [];
+        const seenImages = new Set();
+        normalized.Images = images
+          .map((entry) => toTrimmedString(entry))
+          .filter((entry) => {
+            if (!entry || seenImages.has(entry)) {
+              return false;
+            }
+            seenImages.add(entry);
+            return true;
+          });
+
+        const vintageSource = Array.isArray(rawProduct.VintageProducts)
+          ? rawProduct.VintageProducts
+          : [];
+        normalized.VintageProducts = vintageSource
+          .map((entry) => normalizeVintageProduct(entry))
+          .filter(Boolean);
+
+        return normalized;
+      }
+
       function extractMonittaStoreItems(payload, visited = new WeakSet()) {
         if (payload == null) {
           return [];
@@ -939,48 +1005,10 @@
           urls.push(trimmed);
         };
 
-        const primaryImage = resolveField(product, [
-          "imageUrl",
-          "image",
-          "imageSrc",
-          "imageURL",
-          "thumbnailUrl",
-          "thumbnail",
-          "picture",
-          "photo",
-        ]);
-        if (primaryImage) {
-          collectProductImageUrlsFromValue(primaryImage, addUrl);
-        }
-
-        const galleryFields = [
-          "images",
-          "imageUrls",
-          "image_urls",
-          "imageGallery",
-          "gallery",
-          "galleryImages",
-          "gallery_urls",
-          "photoUrls",
-          "photos",
-          "pictures",
-          "media",
-          "mediaUrls",
-          "mediaItems",
-          "attachments",
-          "thumbnails",
-          "additionalImages",
-          "extraImages",
-          "variants",
-          "variantsImages",
-          "variantsMedia",
-        ];
-
-        for (const key of galleryFields) {
-          if (key in product && product[key] != null && product[key] !== "") {
-            collectProductImageUrlsFromValue(product[key], addUrl);
-          }
-        }
+        const imageEntries = Array.isArray(product.Images) ? product.Images : [];
+        imageEntries.forEach((entry) => {
+          collectProductImageUrlsFromValue(entry, addUrl);
+        });
 
         return urls;
       }
@@ -1269,26 +1297,13 @@
           return [];
         }
 
-        const candidateKeys = [
-          "VintageProducts",
-          "vintageProducts",
-          "relatedProducts",
-        ];
+        const source = Array.isArray(product.VintageProducts)
+          ? product.VintageProducts
+          : [];
 
-        const result = [];
-
-        for (const key of candidateKeys) {
-          const value = product[key];
-          if (Array.isArray(value)) {
-            value.forEach((item) => {
-              if (item != null) {
-                result.push(item);
-              }
-            });
-          }
-        }
-
-        return result;
+        return source
+          .map((entry) => normalizeVintageProduct(entry))
+          .filter(Boolean);
       }
 
       function createVintageListItem(entry, index) {
@@ -1747,51 +1762,17 @@
         });
       }
 
-      function renderProductSummary(product, title) {
+      function renderProductSummary(product) {
         if (!productInfoSection || !productTitleElement || !productDescriptionElement) {
           return;
         }
 
         const hasProduct = product && typeof product === "object";
-        const trimmedTitle = typeof title === "string" ? title.trim() : "";
-        let descriptionText = "";
-
-        if (hasProduct) {
-          const descriptionValue = resolveField(
-            product,
-            [
-              "description",
-              "descriptionText",
-              "description_text",
-              "desc",
-              "details",
-              "productDetails",
-              "product_details",
-              "summary",
-              "productSummary",
-              "productDescription",
-              "descriptionHtml",
-              "descriptionHTML",
-              "htmlDescription",
-              "longDescription",
-              "long_description",
-              "shortDescription",
-              "short_description",
-              "itemDescription",
-              "item_description",
-              "story",
-              "productStory",
-              "notes",
-              "additionalInformation",
-              "additionalInfo",
-            ],
-            "",
-          );
-
-          descriptionText = normalizeText(descriptionValue);
-        }
-
-        const hasTitle = Boolean(trimmedTitle);
+        const titleText = hasProduct ? toTrimmedString(product.Name) : "";
+        const descriptionText = hasProduct
+          ? toTrimmedString(product.Description)
+          : "";
+        const hasTitle = Boolean(titleText);
         const hasDescription = Boolean(descriptionText);
 
         if (!hasTitle && !hasDescription) {
@@ -1805,7 +1786,7 @@
         }
 
         if (hasTitle) {
-          productTitleElement.textContent = trimmedTitle;
+          productTitleElement.textContent = titleText;
           productTitleElement.hidden = false;
         } else {
           productTitleElement.textContent = "";
@@ -1941,7 +1922,7 @@
         updateEditProductLink(productId);
         currentProductData = null;
         currentProductTitle = "";
-        renderProductSummary(null, "");
+        renderProductSummary(null);
         renderVintageProductsList(null);
 
         if (!productId) {
@@ -1964,27 +1945,26 @@
           }
 
           const payload = await response.json();
-          const product = extractProduct(payload);
+          const extracted = extractProduct(payload);
+          const product = normalizeProduct(extracted, productId);
 
           if (!product || typeof product !== "object") {
             currentProductData = null;
             currentProductTitle = "";
-            renderProductSummary(null, "");
+            renderProductSummary(null);
             renderVintageProductsList(null);
             statusElement.textContent = "No product details were returned for this identifier.";
             productCard.hidden = true;
             return;
           }
 
-          const title =
-            resolveField(product, ["name", "title", "productName", "label"], `Product ${productId}`) ||
-            `Product ${productId}`;
+          const title = product.Name || `Product ${productId}`;
           document.title = `${title} – Monitta Store`;
 
           currentProductTitle = title;
           currentProductData = product;
           updateEditProductLink(productId, title);
-          renderProductSummary(product, title);
+          renderProductSummary(product);
           renderVintageProductsList(product);
 
           const imageUrls = getProductImageUrls(product);
@@ -1997,7 +1977,7 @@
           console.error(error);
           currentProductData = null;
           currentProductTitle = "";
-          renderProductSummary(null, "");
+          renderProductSummary(null);
           renderVintageProductsList(null);
           statusElement.hidden = false;
           statusElement.textContent =

--- a/product2.html
+++ b/product2.html
@@ -460,6 +460,72 @@
           title: "",
         };
 
+        function toTrimmedString(value, fallback = "") {
+          if (typeof value === "string") {
+            const trimmed = value.trim();
+            return trimmed || fallback;
+          }
+
+          if (value == null) {
+            return fallback;
+          }
+
+          try {
+            const trimmed = String(value).trim();
+            return trimmed || fallback;
+          } catch (error) {
+            return fallback;
+          }
+        }
+
+        function normalizeVintageProduct(entry) {
+          if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+            return null;
+          }
+
+          const normalized = { ...entry };
+          normalized.VintageProductId = toTrimmedString(entry.VintageProductId);
+          normalized.VintageProductName = toTrimmedString(entry.VintageProductName);
+          normalized.VintageProductUrl = toTrimmedString(entry.VintageProductUrl);
+          return normalized;
+        }
+
+        function normalizeProduct(rawProduct, fallbackId = "") {
+          if (!rawProduct || typeof rawProduct !== "object") {
+            return null;
+          }
+
+          const normalized = { ...rawProduct };
+          const normalizedId = toTrimmedString(
+            rawProduct.id ?? rawProduct.Id ?? rawProduct.ID,
+            fallbackId,
+          );
+          normalized.id = normalizedId;
+          normalized.Name = toTrimmedString(rawProduct.Name);
+          normalized.Description = toTrimmedString(rawProduct.Description);
+
+          const images = Array.isArray(rawProduct.Images) ? rawProduct.Images : [];
+          const seenImages = new Set();
+          normalized.Images = images
+            .map((entry) => toTrimmedString(entry))
+            .filter((entry) => {
+              if (!entry || seenImages.has(entry)) {
+                return false;
+              }
+              seenImages.add(entry);
+              return true;
+            });
+
+          const vintageSource = Array.isArray(rawProduct.VintageProducts)
+            ? rawProduct.VintageProducts
+            : [];
+          normalized.VintageProducts = vintageSource
+            .map((entry) => normalizeVintageProduct(entry))
+            .filter(Boolean);
+
+          return normalized;
+        }
+
         monittaStatusEl.textContent = "Loading related listings…";
         monittaStatusEl.hidden = false;
 
@@ -488,12 +554,23 @@
         async function init(productId) {
           try {
             const product = await fetchProduct(productId);
-            renderProduct(product, productId);
+            const normalizedProduct = normalizeProduct(product, productId);
+            if (!normalizedProduct) {
+              throw new Error("Received an invalid product payload.");
+            }
+
+            renderProduct(normalizedProduct, productId);
             statusEl.hidden = true;
             contentEl.hidden = false;
 
             const { items: monittaItems, error } = await loadMonittaStoreItems();
-            renderMonitta(product?.VintageProducts, monittaItems, error);
+            renderMonitta(
+              Array.isArray(normalizedProduct.VintageProducts)
+                ? normalizedProduct.VintageProducts
+                : [],
+              monittaItems,
+              error,
+            );
           } catch (error) {
             console.error("Failed to load product details.", error);
             statusEl.textContent =
@@ -582,22 +659,11 @@
         }
 
         function renderProduct(product, fallbackProductId) {
-          const title =
-            product?.Name ||
-            product?.name ||
-            product?.Title ||
-            product?.title ||
-            "Product details";
+          const title = product?.Name || "Product details";
           titleEl.textContent = title;
           document.title = `${title} • Product details`;
 
-          const idValue =
-            product?.id ||
-            product?.productId ||
-            product?.productID ||
-            product?.Id ||
-            fallbackProductId ||
-            "";
+          const idValue = product?.id || fallbackProductId || "";
           if (idValue) {
             productIdEl.textContent = `Product ID: ${idValue}`;
             productIdEl.hidden = false;
@@ -605,12 +671,7 @@
             productIdEl.hidden = true;
           }
 
-          const description =
-            product?.Description ||
-            product?.description ||
-            product?.Summary ||
-            product?.summary ||
-            "";
+          const description = product?.Description || "";
 
           if (description) {
             descriptionEl.textContent = description;
@@ -833,22 +894,28 @@
               item.ID ??
               item.vintageProductId ??
               item.vintage_product_id;
-            if (idValue == null) {
+            const normalizedId = toTrimmedString(idValue).toLowerCase();
+            if (!normalizedId) {
               continue;
             }
-            monittaMap.set(String(idValue), item);
+            if (!monittaMap.has(normalizedId)) {
+              monittaMap.set(normalizedId, item);
+            }
           }
 
-          if (Array.isArray(vintageProducts)) {
-            for (const vintage of vintageProducts) {
-              const vintageId = resolveVintageProductId(vintage);
-              if (!vintageId) {
-                continue;
-              }
-              const match = monittaMap.get(String(vintageId));
-              if (match) {
-                matches.push({ vintage, item: match });
-              }
+          const normalizedVintageProducts = Array.isArray(vintageProducts)
+            ? vintageProducts.map((entry) => normalizeVintageProduct(entry)).filter(Boolean)
+            : [];
+
+          for (const vintage of normalizedVintageProducts) {
+            const vintageId = toTrimmedString(vintage?.VintageProductId).toLowerCase();
+            if (!vintageId) {
+              continue;
+            }
+
+            const match = monittaMap.get(vintageId);
+            if (match) {
+              matches.push({ vintage, item: match });
             }
           }
 
@@ -880,36 +947,6 @@
           }
 
           monittaListEl.appendChild(fragment);
-        }
-
-        function resolveVintageProductId(vintageProduct) {
-          if (!vintageProduct) {
-            return "";
-          }
-
-          if (
-            typeof vintageProduct === "string" ||
-            typeof vintageProduct === "number"
-          ) {
-            return String(vintageProduct);
-          }
-
-          const candidateKeys = [
-            "VintageProductId",
-            "vintageProductId",
-            "id",
-            "Id",
-            "productId",
-            "productID",
-          ];
-
-          for (const key of candidateKeys) {
-            if (key in vintageProduct && vintageProduct[key] != null) {
-              return String(vintageProduct[key]);
-            }
-          }
-
-          return "";
         }
 
         function createMonittaCard(vintageProduct, monittaItem) {

--- a/product_add.html
+++ b/product_add.html
@@ -207,10 +207,10 @@
           showMessage("Tworzenie produktu...");
 
           const payload = {
-            name: styleNameInput.value.trim(),
-            description: descriptionInput.value.trim(),
-            images: [],
-            vintageProducts: [],
+            Name: styleNameInput.value.trim(),
+            Description: descriptionInput.value.trim(),
+            Images: [],
+            VintageProducts: [],
           };
 
           try {

--- a/product_edit.html
+++ b/product_edit.html
@@ -741,6 +741,74 @@
           error: null,
         };
 
+        const toTrimmedString = (value, fallback = "") => {
+          if (typeof value === "string") {
+            const trimmed = value.trim();
+            return trimmed || fallback;
+          }
+
+          if (value == null) {
+            return fallback;
+          }
+
+          try {
+            const trimmed = String(value).trim();
+            return trimmed || fallback;
+          } catch (error) {
+            return fallback;
+          }
+        };
+
+        const normalizeVintageProduct = (entry) => {
+          if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+            return null;
+          }
+
+          const normalized = { ...entry };
+          normalized.VintageProductId = toTrimmedString(entry.VintageProductId);
+          normalized.VintageProductName = toTrimmedString(entry.VintageProductName);
+          normalized.VintageProductUrl = toTrimmedString(entry.VintageProductUrl);
+          return normalized;
+        };
+
+        const normalizeProduct = (rawProduct, fallbackId = "") => {
+          if (!rawProduct || typeof rawProduct !== "object") {
+            return null;
+          }
+
+          const normalized = { ...rawProduct };
+          const normalizedId = toTrimmedString(
+            rawProduct.id ?? rawProduct.Id ?? rawProduct.ID,
+            fallbackId,
+          );
+          normalized.id = normalizedId;
+          normalized.Name = toTrimmedString(rawProduct.Name);
+          normalized.Description = toTrimmedString(rawProduct.Description);
+
+          const imageEntries = Array.isArray(rawProduct.Images)
+            ? rawProduct.Images
+            : [];
+          const seenImages = new Set();
+          normalized.Images = imageEntries
+            .map((value) => toTrimmedString(value))
+            .filter((value) => {
+              if (!value || seenImages.has(value)) {
+                return false;
+              }
+              seenImages.add(value);
+              return true;
+            });
+
+          const vintageEntries = Array.isArray(rawProduct.VintageProducts)
+            ? rawProduct.VintageProducts
+            : [];
+          normalized.VintageProducts = vintageEntries
+            .map((entry) => normalizeVintageProduct(entry))
+            .filter(Boolean);
+
+          return normalized;
+        };
+
         const params = new URLSearchParams(window.location.search);
         const productId = params.get("productID") ?? params.get("id");
 
@@ -1399,9 +1467,14 @@
           for (const candidate of candidates) {
             const array = toArray(candidate);
             if (array.length > 0) {
-              return array.map((item) =>
-                typeof item === "object" && item !== null ? cloneProduct(item) : item
-              );
+              return array
+                .map((item) =>
+                  typeof item === "object" && item !== null
+                    ? normalizeVintageProduct(item)
+                    : null,
+                )
+                .filter(Boolean)
+                .map((entry) => cloneProduct(entry));
             }
           }
 
@@ -2938,7 +3011,8 @@
         };
 
         const assignProduct = (product) => {
-          currentProduct = cloneProduct(product);
+          const normalized = normalizeProduct(product, productId);
+          currentProduct = cloneProduct(normalized ?? product);
           populateForm(currentProduct);
 
           if (form) {
@@ -2966,7 +3040,12 @@
             throw new Error("Serwer zwrócił nieoczekiwany format danych.");
           }
 
-          return product;
+          const normalized = normalizeProduct(product, productId);
+          if (!normalized) {
+            throw new Error("Odebrano nieprawidłowe dane produktu.");
+          }
+
+          return normalized;
         };
 
         const buildUpdatePayload = () => {
@@ -3164,7 +3243,8 @@
             }
 
             if (updatedProduct && typeof updatedProduct === "object") {
-              assignProduct(updatedProduct);
+              const normalizedUpdate = normalizeProduct(updatedProduct, productId);
+              assignProduct(normalizedUpdate ?? updatedProduct);
             } else {
               try {
                 const refreshed = await fetchProductDetails();
@@ -3184,7 +3264,11 @@
                 const refreshedProduct = await uploadProductImages(productId, selectedFiles);
 
                 if (refreshedProduct && typeof refreshedProduct === "object") {
-                  assignProduct(refreshedProduct);
+                  const normalizedRefreshed = normalizeProduct(
+                    refreshedProduct,
+                    productId,
+                  );
+                  assignProduct(normalizedRefreshed ?? refreshedProduct);
                   setStatus("Zmiany produktu oraz zdjęcia zostały zapisane.", "success");
                 } else {
                   setStatus(


### PR DESCRIPTION
## Summary
- normalize product API responses so detail pages rely on the canonical fields and sanitized collections
- ensure the product editor loads, updates and uploads data using the `Product`/`VintageProduct` structure
- send correctly-cased field names when creating new products

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd15e470cc83258e5fbffa7598f358