### PR TITLE
Remove subtitle and status message from index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,22 +74,6 @@
         color: #101827;
       }
 
-      .intro {
-        margin: 0 auto;
-        max-width: 60ch;
-        color: #52606d;
-        font-size: 1.05rem;
-        line-height: 1.6;
-      }
-
-      #status {
-        margin: 0 auto clamp(1.75rem, 4vw, 2.5rem);
-        max-width: 60ch;
-        text-align: center;
-        color: #3d4852;
-        font-weight: 500;
-      }
-
       #product-grid {
         list-style: none;
         padding: 0;
@@ -192,12 +176,7 @@
           <a class="add-product-link" href="product_add.html">Add Product</a>
         </div>
         <h1>Monitta Store Products</h1>
-        <p class="intro">
-          Browse the latest products fetched directly from the Monitta Store product API.
-        </p>
       </header>
-
-      <p id="status" role="status" aria-live="polite">Loading products…</p>
 
       <ul id="product-grid" hidden aria-label="Products"></ul>
 
@@ -219,7 +198,6 @@
     <script>
       const endpoint =
         "https://vintagecrawlerappservice-hqb0f5bmfrdwf0g7.polandcentral-01.azurewebsites.net/products";
-      const statusElement = document.getElementById("status");
       const gridElement = document.getElementById("product-grid");
       const template = document.getElementById("product-card-template");
 
@@ -299,7 +277,6 @@
       }
 
       async function loadProducts() {
-        statusElement.textContent = "Loading products…";
         try {
           const response = await fetch(endpoint);
           if (!response.ok) {
@@ -318,7 +295,8 @@
             : [];
 
           if (!products.length) {
-            statusElement.textContent = "No products found.";
+            gridElement.innerHTML = "";
+            gridElement.hidden = false;
             return;
           }
 
@@ -393,13 +371,8 @@
           gridElement.innerHTML = "";
           gridElement.appendChild(fragment);
           gridElement.hidden = false;
-          statusElement.textContent = `Loaded ${products.length} product${
-            products.length === 1 ? "" : "s"
-          }.`;
         } catch (error) {
           console.error(error);
-          statusElement.textContent =
-            "Unable to load products. Please check the API availability and try again.";
         }
       }
 


### PR DESCRIPTION
## Summary
- remove the subtitle paragraph from the product list page so only the title remains
- eliminate the status text element and adjust the loader script to show only the product grid

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd1da2113c8325b265cd7c98dc1150