### PR TITLE
Hide image filenames and remove Monitta link label

### DIFF
--- a/product_edit.html
+++ b/product_edit.html
@@ -2330,16 +2330,6 @@
             addButton.textContent = "Dodaj do vintage";
             actions.appendChild(addButton);
 
-            if (entry.url) {
-              const link = document.createElement("a");
-              link.href = entry.url;
-              link.target = "_blank";
-              link.rel = "noopener";
-              link.className = "monitta-option__link";
-              link.textContent = "Zobacz na Monitta Store";
-              actions.appendChild(link);
-            }
-
             listItem.appendChild(actions);
 
             fragment.appendChild(listItem);
@@ -2629,10 +2619,6 @@
             img.alt = altText;
             figure.appendChild(img);
 
-            const caption = document.createElement("figcaption");
-            caption.textContent = altText;
-            figure.appendChild(caption);
-
             imagesContainer.appendChild(figure);
             rendered += 1;
           });
@@ -2707,15 +2693,12 @@
           imageFiles.forEach((file, index) => {
             const figure = document.createElement("figure");
             const img = document.createElement("img");
-            const caption = document.createElement("figcaption");
             const label = file.name && file.name.trim() ? file.name : `Nowe zdjęcie ${index + 1}`;
 
             img.loading = "lazy";
             img.alt = label;
-            caption.textContent = label;
 
             figure.appendChild(img);
-            figure.appendChild(caption);
             newImagesPreview.appendChild(figure);
 
             const reader = new FileReader();


### PR DESCRIPTION
## Summary
- remove the rendered captions below product images so filenames are no longer shown on the edit page
- drop the Monitta Store link label from product list entries to eliminate the "Zobacz na Monitta Store" text

## Testing
- Not run (static HTML updates)


------
https://chatgpt.com/codex/tasks/task_e_68cd3fbeb5808325a386cc07cdedc92d