### PR TITLE
Use direct product image URLs

### DIFF
--- a/product.html
+++ b/product.html
@@ -548,37 +548,8 @@
       const monittaStoreItemsById = new Map();
       let currentProductData = null;
       let currentProductTitle = "";
-      const imageBaseUrl =
-        "https://buythelookvintagestorage.blob.core.windows.net/uploads/";
-      const imageSasToken =
-        "sv=2024-11-04&ss=bfqt&srt=sco&sp=rl&se=2026-09-18T22:54:01Z&st=2025-09-18T14:39:01Z&spr=https&sig=roACoFS1yrHnyvMnUZWwy7w1VTfvQBL2jRCA9zGRdfA%3D";
-      const imageContainerUrl = new URL(imageBaseUrl);
-      const imageContainerHost = imageContainerUrl.host;
-      const imageContainerHostLower = imageContainerHost.toLowerCase();
-      const imageContainerPath = imageContainerUrl.pathname.replace(/^[\\/]+/, "");
-      const imageContainerPathPrefix =
-        imageContainerPath && !imageContainerPath.endsWith("/")
-          ? `${imageContainerPath}/`
-          : imageContainerPath;
-      const imageContainerPathPrefixLower = imageContainerPathPrefix
-        ? imageContainerPathPrefix.toLowerCase()
-        : "";
-      const imageSasEntries = Array.from(
-        new URLSearchParams(
-          imageSasToken.startsWith("?")
-            ? imageSasToken.slice(1)
-            : imageSasToken,
-        ),
-      );
-
       if (typeof window !== "undefined") {
         window.monittaStoreItems = monittaStoreItems;
-      }
-
-      function appendImageSasParams(url) {
-        for (const [key, value] of imageSasEntries) {
-          url.searchParams.set(key, value);
-        }
       }
 
       function toTrimmedString(value, fallback = "") {
@@ -741,6 +712,10 @@
           return buildProductImageUrl(value.valueOf());
         }
 
+        if (value instanceof URL) {
+          return value.href;
+        }
+
         if (Array.isArray(value)) {
           for (const candidate of value) {
             const resolved = buildProductImageUrl(candidate);
@@ -754,16 +729,39 @@
         if (value && typeof value === "object") {
           const candidateKeys = [
             "url",
+            "URL",
             "href",
+            "Href",
+            "link",
+            "Link",
             "src",
+            "Src",
             "imageUrl",
+            "ImageUrl",
+            "imageURL",
+            "ImageURL",
             "image",
+            "Image",
+            "imageSrc",
+            "ImageSrc",
             "thumbnailUrl",
+            "ThumbnailUrl",
+            "thumbnailURL",
+            "ThumbnailURL",
             "thumbnail",
+            "Thumbnail",
             "picture",
+            "Picture",
             "photo",
+            "Photo",
+            "photoUrl",
+            "PhotoUrl",
+            "photoURL",
+            "PhotoURL",
             "path",
+            "Path",
             "value",
+            "Value",
           ];
 
           for (const key of candidateKeys) {
@@ -775,99 +773,30 @@
             }
           }
 
-          if (value instanceof URL) {
-            return buildProductImageUrl(value.href);
-          }
-
           return "";
         }
 
-        const stringValue = typeof value === "string" ? value : String(value);
+        let stringValue;
+        if (typeof value === "string") {
+          stringValue = value;
+        } else {
+          try {
+            stringValue = String(value);
+          } catch (error) {
+            return "";
+          }
+        }
         const trimmedValue = stringValue.trim();
         if (!trimmedValue) {
           return "";
         }
 
         const sanitizedValue = trimmedValue.replace(/\\/g, "/");
-        const sanitizedValueLower = sanitizedValue.toLowerCase();
-
-        const nonHttpSchemeMatch = /^[a-z][a-z\d+\-.]*:/i.exec(sanitizedValue);
-        if (
-          nonHttpSchemeMatch &&
-          !/^https?:/i.test(sanitizedValue) &&
-          !/^[a-z]:[\\/]/i.test(trimmedValue)
-        ) {
-          return sanitizedValue;
+        if (sanitizedValue.startsWith("//")) {
+          return `https:${sanitizedValue}`;
         }
 
-        const hasHttpScheme = /^https?:/i.test(sanitizedValue);
-        const protocolRelative =
-          sanitizedValue.startsWith("//") || trimmedValue.startsWith("//");
-        if (hasHttpScheme || protocolRelative) {
-          try {
-            const candidateValue = protocolRelative
-              ? `https:${sanitizedValue}`
-              : sanitizedValue;
-            const absoluteUrl = new URL(candidateValue);
-            const inImageContainer =
-              absoluteUrl.host === imageContainerHost &&
-              absoluteUrl.pathname.startsWith(imageContainerUrl.pathname);
-
-            if (inImageContainer) {
-              appendImageSasParams(absoluteUrl);
-              return absoluteUrl.toString();
-            }
-
-            return absoluteUrl.toString();
-          } catch (error) {
-            return sanitizedValue;
-          }
-        }
-
-        if (
-          sanitizedValueLower.includes(imageContainerHostLower) &&
-          !sanitizedValue.includes("://")
-        ) {
-          try {
-            const normalizedValue = sanitizedValue.replace(/^[\\/]+/, "");
-            const azureUrl = new URL(`https://${normalizedValue}`);
-            const inImageContainer =
-              azureUrl.host === imageContainerHost &&
-              azureUrl.pathname.startsWith(imageContainerUrl.pathname);
-
-            if (inImageContainer) {
-              appendImageSasParams(azureUrl);
-              return azureUrl.toString();
-            }
-          } catch (error) {
-            // Continue to normalized path handling below if parsing fails
-          }
-        }
-
-        let normalizedPath = sanitizedValue.replace(/^[a-z]:[\\/]+/i, "");
-        normalizedPath = normalizedPath.replace(/^[\\/]+/, "");
-        if (!normalizedPath) {
-          return "";
-        }
-
-        if (imageContainerPathPrefix) {
-          const normalizedPathLower = normalizedPath.toLowerCase();
-          if (normalizedPathLower.startsWith(imageContainerPathPrefixLower)) {
-            normalizedPath = normalizedPath.slice(imageContainerPathPrefix.length);
-          }
-        }
-
-        try {
-          const resolvedUrl = new URL(normalizedPath, imageContainerUrl);
-          appendImageSasParams(resolvedUrl);
-          return resolvedUrl.toString();
-        } catch (error) {
-          const base = imageBaseUrl.endsWith("/")
-            ? imageBaseUrl
-            : `${imageBaseUrl}/`;
-          const prefix = imageSasToken.startsWith("?") ? "" : "?";
-          return `${base}${normalizedPath}${prefix}${imageSasToken}`;
-        }
+        return sanitizedValue;
       }
 
       function collectProductImageUrlsFromValue(value, addUrl, visited = new Set()) {

--- a/product_edit.html
+++ b/product_edit.html
@@ -727,11 +727,6 @@
         const monittaEndpoint =
           "https://vintagecrawlerappservice-hqb0f5bmfrdwf0g7.polandcentral-01.azurewebsites.net/MonittaStore";
 
-        const blobImageBaseUrl =
-          "https://buythelookvintagestorage.blob.core.windows.net/uploads/";
-        const blobImageQuery =
-          "?sv=2024-11-04&ss=bfqt&srt=sco&sp=rl&se=2026-09-18T22:54:01Z&st=2025-09-18T14:39:01Z&spr=https&sig=roACoFS1yrHnyvMnUZWwy7w1VTfvQBL2jRCA9zGRdfA%3D";
-
         const monittaState = {
           isLoading: true,
           filter: "",
@@ -1589,40 +1584,34 @@
             return "";
           }
 
+          if (typeof File !== "undefined" && image instanceof File) {
+            const fileName = image.name && image.name.trim() ? image.name.trim() : "";
+            return fileName;
+          }
+
+          if (image instanceof String) {
+            return toImageStringForPayload(image.valueOf());
+          }
+
+          const urlCandidate = buildImageUrlFromEntry(image);
+          if (urlCandidate) {
+            return urlCandidate;
+          }
+
           if (
             typeof image === "string" ||
             typeof image === "number" ||
             typeof image === "bigint"
           ) {
-            const text = toDisplayString(image).trim();
-            if (!text) {
+            try {
+              const text = toDisplayString(image).trim();
+              return text;
+            } catch (error) {
               return "";
             }
-            const normalized = normalizeBlobFile(text);
-            return normalized || text;
-          }
-
-          if (typeof File !== "undefined" && image instanceof File) {
-            const fileName = image.name && image.name.trim() ? image.name.trim() : "";
-            if (!fileName) {
-              return "";
-            }
-            const normalized = normalizeBlobFile(fileName);
-            return normalized || fileName;
           }
 
           if (typeof image === "object") {
-            const fileCandidate = resolveImageFileCandidate(image);
-            if (fileCandidate) {
-              return fileCandidate;
-            }
-
-            const urlCandidate = resolveImageUrlCandidate(image);
-            if (urlCandidate) {
-              const normalizedUrl = normalizeBlobFile(urlCandidate);
-              return normalizedUrl || urlCandidate;
-            }
-
             const directCandidate = resolveField(
               image,
               [
@@ -1648,15 +1637,23 @@
             );
 
             if (directCandidate != null && directCandidate !== "") {
-              const text = toDisplayString(directCandidate).trim();
-              if (text) {
-                const normalized = normalizeBlobFile(text);
-                return normalized || text;
+              try {
+                const text = toDisplayString(directCandidate).trim();
+                if (text) {
+                  return text;
+                }
+              } catch (error) {
+                return "";
               }
             }
           }
 
-          return "";
+          try {
+            const text = toDisplayString(image).trim();
+            return text;
+          } catch (error) {
+            return "";
+          }
         };
 
         const gatherImagesForPayload = (...sources) => {
@@ -1976,43 +1973,107 @@
           return "";
         };
 
-        const resolveImageUrlCandidate = (image) => {
-          if (typeof image === "string") {
-            const text = toDisplayString(image).trim();
-            return isAbsoluteUrl(text) ? text : "";
-          }
-
-          if (image && typeof image === "object") {
-            const candidate = resolveField(
-              image,
-              ["url", "imageUrl", "src", "href", "link"],
-              ""
-            );
-            const text = candidate != null ? toDisplayString(candidate).trim() : "";
-            return isAbsoluteUrl(text) ? text : "";
-          }
-
-          return "";
-        };
-
         const buildImageUrlFromEntry = (image) => {
-          const absoluteUrl = resolveImageUrlCandidate(image);
-          const normalizedFromUrl = normalizeBlobFile(absoluteUrl);
-
-          if (normalizedFromUrl) {
-            return `${blobImageBaseUrl}${normalizedFromUrl}${blobImageQuery}`;
+          if (image == null) {
+            return "";
           }
 
-          const fileCandidate = resolveImageFileCandidate(image);
-          if (fileCandidate) {
-            return `${blobImageBaseUrl}${fileCandidate}${blobImageQuery}`;
+          if (image instanceof String) {
+            return buildImageUrlFromEntry(image.valueOf());
           }
 
-          if (absoluteUrl) {
-            return absoluteUrl;
+          if (image instanceof URL) {
+            return image.href;
           }
 
-          return "";
+          if (Array.isArray(image)) {
+            for (const candidate of image) {
+              const resolved = buildImageUrlFromEntry(candidate);
+              if (resolved) {
+                return resolved;
+              }
+            }
+            return "";
+          }
+
+          if (typeof image === "object") {
+            const candidateKeys = [
+              "url",
+              "URL",
+              "href",
+              "Href",
+              "link",
+              "Link",
+              "src",
+              "Src",
+              "imageUrl",
+              "ImageUrl",
+              "imageURL",
+              "ImageURL",
+              "image",
+              "Image",
+              "imageSrc",
+              "ImageSrc",
+              "thumbnailUrl",
+              "ThumbnailUrl",
+              "thumbnailURL",
+              "ThumbnailURL",
+              "thumbnail",
+              "Thumbnail",
+              "picture",
+              "Picture",
+              "pictureUrl",
+              "PictureUrl",
+              "pictureURL",
+              "PictureURL",
+              "photo",
+              "Photo",
+              "photoUrl",
+              "PhotoUrl",
+              "path",
+              "Path",
+              "value",
+              "Value",
+            ];
+
+            for (const key of candidateKeys) {
+              const candidateValue = resolveField(image, [key], null);
+              if (candidateValue != null && candidateValue !== "") {
+                const resolved = buildImageUrlFromEntry(candidateValue);
+                if (resolved) {
+                  return resolved;
+                }
+              }
+            }
+
+            return "";
+          }
+
+          let text;
+          try {
+            text = toDisplayString(image).trim();
+          } catch (error) {
+            return "";
+          }
+
+          if (!text) {
+            return "";
+          }
+
+          const sanitized = text.replace(/\\/g, "/");
+          if (/^https?:\/\//i.test(sanitized)) {
+            return sanitized;
+          }
+
+          if (sanitized.startsWith("//")) {
+            return `https:${sanitized}`;
+          }
+
+          if (/^(data|blob):/i.test(sanitized)) {
+            return sanitized;
+          }
+
+          return sanitized;
         };
 
         const findFirstImageUrl = (...sources) => {


### PR DESCRIPTION
## Summary
- remove the Azure blob base/SAS handling on the product page and use the URLs returned with each product image
- simplify the product editor image helpers to rely on the URLs provided by the API when rendering and preparing payloads

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd3e6e006c8325a24e27711d2a261d