### PR TITLE
Handle case-sensitive product creation response

### DIFF
--- a/product_add.html
+++ b/product_add.html
@@ -229,12 +229,8 @@
               throw new Error(`Żądanie nie powiodło się (status: ${response.status})`);
             }
 
-            const productDetails = await response.json();
-            const productId =
-              productDetails?.id ??
-              productDetails?.productId ??
-              productDetails?.productID ??
-              productDetails?.Id;
+            const { id } = await response.json();
+            const productId = typeof id === "string" ? id.trim() : "";
 
             if (!productId) {
               showMessage(


### PR DESCRIPTION
## Summary
- simplify product creation response parsing by relying on the case-sensitive `id` field returned by the API
- trim and validate the received identifier before redirecting

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd7b343c7c8325ba9192f43b9b730b