### PR TITLE
Fix vintage section overflow on product page

### DIFF
--- a/product.html
+++ b/product.html
@@ -154,7 +154,6 @@
         border-radius: 18px;
         padding: clamp(1rem, 2.2vw, 1.25rem);
         box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.12);
-        min-height: 100%;
         flex: 1 1 auto;
       }
 


### PR DESCRIPTION
## Summary
- ensure the Vintage products panel flexes naturally so it no longer extends past the product card boundaries

## Testing
- ⚠️ not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd7d2ca03c83258e92f97c9f311a45